### PR TITLE
Use covidcast image during build

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -1,5 +1,2 @@
 # docker image for setting up an R environment
-FROM rocker/tidyverse
-
-ADD ./dependencies.R .
-RUN Rscript ./dependencies.R
+FROM ghcr.io/cmu-delphi/covidcast:latest

--- a/docker_build/dependencies.R
+++ b/docker_build/dependencies.R
@@ -1,8 +1,3 @@
 # Tidyverse is installed in the base image
 # Other packages should be installed here
 
-install.packages("assertthat")
-install.packages("optparse")
-install.packages("doParallel")
-
-devtools::install_github("cmu-delphi/covidcast",ref = "evalcast-killcards",subdir = "R-packages/evalcast")


### PR DESCRIPTION
This should significantly improve local build times, as well as obviate any issues with building the covidcast package from source using devtools.