### PR TITLE
Update from evalcast-killcards to evalcast and reduce memory issues

### DIFF
--- a/Report/predictions.R
+++ b/Report/predictions.R
@@ -7,7 +7,7 @@ library(stringr)
 create_prediction_cards = function(prediction_cards_filename){
   start_date = today() - 100 * 7 # last 100 weeks
   
-  forecasters = get_covidhub_forecaster_names()
+  forecasters = get_covidhub_forecaster_names(designations = "primary")
   num_forecasters = length(forecasters)
   print(str_interp("Getting forecasts for ${num_forecasters} forecasters."))
   
@@ -20,7 +20,10 @@ create_prediction_cards = function(prediction_cards_filename){
     error = function(e) cat(sprintf("%i. %s\n", i, e$message))
     )
   }
-  
+  # Convert NULL to empty vector. Useful when a model has no forecasts,
+  # resulting in a 404 and no forecast_dates.
+  forecast_dates = lapply(forecast_dates,
+                          function(dates) if (is.null(dates)) Date() else dates)
   forecast_dates = lapply(forecast_dates, function(date) date[date >= start_date])
   
   # Load data from previous run so we don't have to re-ingest / process it. This

--- a/Report/score.R
+++ b/Report/score.R
@@ -56,9 +56,8 @@ create_score_cards = function(prediction_cards_filepath, geo_type, signal_name =
   }
 
   if(nrow(preds_to_eval) > 0){
-    score_cards = evaluate_predictions(preds_to_eval, 
+    score_cards = evaluate_covid_predictions(preds_to_eval, 
                                            err_measures,
-                                           backfill_buffer = 0,
                                            geo_type = geo_type)
     # filter out scores that couldn't be evaluated to try to evaluate with
     # covidHubUtils.


### PR DESCRIPTION
Requirements:
This PR requires an update from `evalcast-killcards` to `evalcast`.

Memory related fixes:
1.) Update from evalcast-killcards to evalcast. Evalcast does not have memoisation, which will reduce memory requirements
2.) Only retrieve forecasts designated as "primary". Reduces memory requirements and aligns evaluation with Reich Lab documentation

Additionally, fixes a bug when processing `forecast_dates` for a forecaster that has no associated forecasts.