### PR TITLE
Add wis component scores

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -67,6 +67,9 @@ coverage_functions = sapply(central_intervals,
 names(coverage_functions) = cov_names
 
 err_measures = c(wis = weighted_interval_score,
+                 overprediction = overprediction,
+                 underprediction = underprediction,
+                 sharpness = sharpness,
                  ae = absolute_error,
                  coverage_functions)
 

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -80,6 +80,10 @@ err_measures = c(wis = weighted_interval_score,
 nation_predictions = predictions_cards %>% filter(geo_value == "us")
 state_predictions = predictions_cards %>% filter(geo_value != "us")
 
+# predictions_cards not needed beyond this point, try free up the memory
+rm(predictions_cards)
+gc()
+
 print("Evaluating state forecasts")
 state_scores = evaluate_covid_predictions(state_predictions,
                                           err_measures,

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -66,6 +66,10 @@ coverage_functions = sapply(central_intervals,
                             function(coverage) interval_coverage(coverage))
 names(coverage_functions) = cov_names
 
+# TODO: Contains fixed versions of WIS component metrics, to be ported over to evalcast
+# Redefines overprediction, underprediction and sharpness
+source("error_measures.R")
+
 err_measures = c(wis = weighted_interval_score,
                  overprediction = overprediction,
                  underprediction = underprediction,

--- a/Report/error_measures.R
+++ b/Report/error_measures.R
@@ -1,0 +1,93 @@
+library(assertthat)
+
+overprediction <- function(quantile, value, actual_value) {
+  score_func_param_checker(quantile, value, actual_value, "overprediction")
+  if (!is_symmetric(quantile)) {
+    warning(paste0("overprediction/underprediction/sharpness require",
+                   "symmetric quantile forecasts. Using NA."))
+    return(NA)
+  }
+  if (all(is.na(actual_value))) return(NA)
+  actual_value <- unique(actual_value)
+  
+  lower <- value[!is.na(quantile) & quantile < .5]
+  med <- value[find_quantile_match(quantile, 0.5)]
+  
+  if (length(med) > 1L) {
+    return(NA)
+  } else if (length(med) == 1L) {
+    m <- (med - actual_value) * (med > actual_value)
+  } else {
+    m <- NULL
+  }
+  
+  ans <- mean(c(
+    rep((lower - actual_value) * (lower > actual_value), 2), m))
+  
+  
+  return(ans)
+}
+
+underprediction <- function(quantile, value, actual_value) {
+  score_func_param_checker(quantile, value, actual_value, "underprediction")
+  if (!is_symmetric(quantile)) {
+    warning(paste0("overprediction/underprediction/sharpness require",
+                   "symmetric quantile forecasts. Using NA."))
+    return(NA)
+  }
+  if (all(is.na(actual_value))) return(NA)
+  actual_value <- unique(actual_value)
+  
+  upper <- value[!is.na(quantile) & quantile > .5]
+  med <- value[find_quantile_match(quantile, 0.5)]
+  
+  if (length(med) > 1L) {
+    return(NA)
+  } else if (length(med) == 1L) {
+    m <- (actual_value - med) * (med < actual_value)
+  } else {
+    m <- NULL
+  }
+  
+  ans <- mean(c(
+    rep((actual_value - upper) * (upper < actual_value), 2), m))
+  
+  return(ans)
+}
+
+sharpness <- function(quantile, value, actual_value) {
+  weighted_interval_score(quantile, value, actual_value) - 
+    overprediction(quantile, value, actual_value) - 
+    underprediction(quantile, value, actual_value)
+}
+
+# Utility functions required from evalcast that are not exported
+
+is_symmetric <- function(x, tol=1e-8) {
+  x <- sort(x)
+  all(abs(x + rev(x) - 1) < tol)
+}
+
+find_quantile_match <- function(quantiles, val_to_match, tol=1e-8){
+  return(abs(quantiles - val_to_match) < tol  & !is.na(quantiles))
+}
+
+score_func_param_checker <- function(quantiles, values, actual_value, id = ""){
+  id_str = paste0(id, ": ")
+  if (length(actual_value) > 1) {
+    assert_that(length(actual_value) == length(values),
+                msg = paste0(id_str, 
+                             "actual_value must be a scalar or the same length",
+                             " as values"))
+    actual_value = unique(actual_value)
+  }
+  assert_that(length(actual_value) == 1,
+              msg = paste0(id_str,
+                           "actual_value must have exactly 1 unique value"))
+  assert_that(length(quantiles) == length(values),
+              msg = paste0(id_str, 
+                           "quantiles and values must be of the same length"))
+  assert_that(!any(duplicated(quantiles)),
+              msg = paste0(id_str,
+                           "quantiles must be unique."))
+}


### PR DESCRIPTION
Adds WIS component scores (overprediction, underprediction and sharpness) to score cards.

Note: Must use a version of evalcast that includes https://github.com/cmu-delphi/covidcast/pull/515. Else, component scores will show as NA in most cases.