### PR TITLE
Remove legend title

### DIFF
--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -400,7 +400,8 @@ server <- function(input, output, session) {
       facet_wrap(~ahead, ncol=1) +
       scale_color_manual(values = colorPalette) +
       theme_bw() + 
-      theme(panel.spacing=unit(0.5, "lines"))
+      theme(panel.spacing=unit(0.5, "lines")) +
+      theme(legend.title = element_blank())
 
     if (scoreType == "coverage") {
       p = p + geom_hline(yintercept = .01 * as.integer(coverageInterval))


### PR DESCRIPTION
- Removes legend title so the first letter does not peak out on the side of the plot

- Before:
<img width="948" alt="Screen Shot 2021-06-15 at 12 16 13 PM" src="https://user-images.githubusercontent.com/14190352/122088161-7fbfc580-cdd3-11eb-9024-b6f2d9772911.png">

- After:
<img width="960" alt="Screen Shot 2021-06-15 at 12 13 02 PM" src="https://user-images.githubusercontent.com/14190352/122087953-4d15cd00-cdd3-11eb-9999-279920092cd2.png">
