### PR TITLE
Force pipeline container build to always pull newest covidcast image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ S3_BUCKET=s3://forecast-eval
 build: build_dashboard
 
 r_build:
-	docker build -t forecast-eval-build docker_build
+	docker build --no-cache --pull -t forecast-eval-build docker_build
 
 predictions_cards.rds score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds: dist
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@ 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ deploy: score_forecast
 
 # Starts a docker image with a full preconfigured R environment
 start_dev: r_build
-	docker run -ti --rm \
+	docker run --pull=always -ti --rm \
 		-v ${PWD}/Report:/var/forecast-eval \
 		-v ${PWD}/dashboard:/var/forecast-eval-dashboard \
 		-v ${PWD}/dist:/var/dist \
@@ -40,13 +40,13 @@ start_dev: r_build
 		ghcr.io/cmu-delphi/forecast-eval:latest bash
 
 build_dashboard_dev: pull_data
-	docker build -t ghcr.io/cmu-delphi/forecast-eval:latest -f docker_dashboard/Dockerfile .
+	docker build --no-cache --pull -t ghcr.io/cmu-delphi/forecast-eval:latest -f docker_dashboard/Dockerfile .
 
 build_dashboard: pull_data
-	docker build --no-cache=true -t ghcr.io/cmu-delphi/forecast-eval:$(imageTag) -f docker_dashboard/Dockerfile .
+	docker build --no-cache=true --pull -t ghcr.io/cmu-delphi/forecast-eval:$(imageTag) -f docker_dashboard/Dockerfile .
 
 deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
-	docker run --rm -p 3838:3838 ghcr.io/cmu-delphi/forecast-eval:latest
+	docker run --pull=always --rm -p 3838:3838 ghcr.io/cmu-delphi/forecast-eval:latest


### PR DESCRIPTION
### Description
When building or running a docker image from an online repo, force it to always pull the most recent docker image from the repo (`--pull` flag for `build`, `--pull=always` for `run`) and run all contents (`--no-cache` flag) anew for building. The `--no-cache` flag is not strictly necessary in Dockerfiles that aren't running commands other than the `FROM` statement, but it's a good hedge against future problems of this nature.

### Changes
- Add `--no-cache` and `--pull` flags to `r_build` `make` target.
- Add `--no-cache` and `--pull` flags to `build_dashboard` target.
- Add `--no-cache` and `--pull` flags to `build_dashboard_dev` target.
- Add `--pull=always` flag to `start_dev` target.
- Add `--pull=always` flag to `start_dashboard` target.

### Fixes
The self-hosted dashboard pipeline has not been using updated [`covidcast` docker images](https://github.com/cmu-delphi/covidcast-docker/tree/main/docker); it has been using a [version of the image](https://github.com/orgs/cmu-delphi/packages/container/covidcast/2187591) (resulting image ID: `6dcbc96bdc6a`) that is 2 months old. This means that no recent code changes have been incorporated into the pipeline runs.

Although the `covidcast` docker image has been building and pushing correctly to [`ghcr.io/cmu-delphi/covidcast`](https://github.com/orgs/cmu-delphi/packages/container/covidcast/versions?filters%5Bversion_type%5D=untagged), the forecast-eval docker container (`docker_build`) that uses it has not been pulling the most recent versions. Because the pipeline is currently self-hosted and the machine state is persistent, there is always a local version of `ghcr.io/cmu-delphi/covidcast:latest`. By default, `docker build` looks for a local version of the requested base image; docker only pulls a newer version from the image repository [if an image with matching name and tag is not found locally](https://github.com/moby/moby/issues/4238).

This didn't happen when running the workflow hosted by GitHub, because GitHub [doesn't save the machine state between runs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).