### PR TITLE
Let `start_dashboard` use local docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
-	docker run --pull=always --rm -p 3838:3838 ghcr.io/cmu-delphi/forecast-eval:latest
+	docker run --rm -p 3838:3838 ghcr.io/cmu-delphi/forecast-eval:latest


### PR DESCRIPTION
### Description
Remove force pull in `start_dashboard` docker run.

### Fixes
#125 overzealously forces the `start_dashboard` make target to pull the latest version of the `ghcr.io/cmu-delphi/forecast-eval` container from the registry. Since a local dev container is created with the same name and tag by the `build_dashboard_dev` target, run before `start_dashboard`, it is always overwritten and it isn't possible to run the dev version of the dashboard.