### PR TITLE
Drop hospitalizations forecasts for most US territories

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -48,10 +48,10 @@ predictions_cards = predictions_cards %>%
     filter(target_end_date < today())
 
 # For hospitalizations, drop all US territories except Puerto Rico and the
-# Virgin Islands; HHS does not report data for these.
+# Virgin Islands; HHS does not report data for any territories except PR and VI.
 territories <- c("as", "gu", "mp", "fm", "mh", "pw", "um")
 predictions_cards = predictions_cards %>%
-    filter(!(geo_value %in% territories), data_source != "hhs")
+    filter(!(geo_value %in% territories & data_source == "hhs"))
 
 # For epiweek predictions, only accept forecasts made Monday or earlier.
 # target_end_date is the date of the last day (Saturday) in the epiweek

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -44,8 +44,14 @@ predictions_cards = get_covidhub_predictions(forecasters,
     filter(!(incidence_period == "epiweek" & ahead > 4))
 
 predictions_cards = predictions_cards %>%
-    filter(!is.na(predictions_cards$target_end_date)) %>%
+    filter(!is.na(target_end_date)) %>%
     filter(target_end_date < today())
+
+# For hospitalizations, drop all US territories except Puerto Rico and the
+# Virgin Islands; HHS does not report data for these.
+territories <- c("as", "gu", "mp", "fm", "mh", "pw", "um")
+predictions_cards = predictions_cards %>%
+    filter(!(geo_value %in% territories), data_source != "hhs")
 
 # For epiweek predictions, only accept forecasts made Monday or earlier.
 # target_end_date is the date of the last day (Saturday) in the epiweek


### PR DESCRIPTION
Drop hospitalizations forecasts for US territories that HHS does not report for. This filter is narrow so that other forecasts with missing actuals and/or scores continue to be carried through to the S3 bucket.