### PR TITLE
Save predictions cards to directory passed as command line arg

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -66,7 +66,7 @@ class(predictions_cards) = c("predictions_cards", class(predictions_cards))
 
 print("Saving predictions...")
 saveRDS(predictions_cards,
-        file = "predictions_cards.rds",
+        file = prediction_cards_filepath,
         compress = "xz")
 print("Predictions saved")
 


### PR DESCRIPTION
### Description
Save `predictions_cards.rds` to the directory passed as a command-line argument, if provided, else uses the working directory.

### Fixes
Closes #142.

Fixes out-of-date `predictions_cards.rds` in the dashboard backend. The `deploy` make target has as a nested dependency the `predictions_cards.rds`, which saves a copy of `predictions_cards.rds` from the S3 bucket to the local `dist` dir; files are uploaded to the S3 bucket from this directory as well. The old file is overwritten by the new copy of `predictions_cards.rds` generated by the current run if saved to the same directory. However, `predictions_cards.rds` has been saved to the current working directory (`Report`) instead and thus the downloaded copy is never overwritten.