### PR TITLE
Change repo dir owner to action user so files can be deleted

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -19,6 +19,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Change dir owner to working user
+        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         


### PR DESCRIPTION
### Description
Some (but oddly not all) data files from a previous run of this action are created with root as the owner. Because the action runs as a non-root user, such files are [not able to be deleted](https://github.com/cmu-delphi/forecast-eval/runs/3351290227?check_suite_focus=true) which is necessary for the `actions/checkout@v2` step to install the newest version of the repo.

This seems to be a bug in the `actions/checkout@v2` command. [Summary of issue](https://github.com/actions/runner/issues/691) and [suggested fixes](https://github.com/actions/checkout/issues/211).

This problem seems to happen rarely (this is the first occurrence). It is unclear why it started happening -- the [checkout action](https://github.com/actions/checkout) hasn't released a new version recently, and our workflow and code haven't changed.

This fix changes the owner of the directory from root to the actions working user so that the user is allowed to delete it (requires passwordless sudo or password stored in GitHub Actions secrets).

### Changes
- Explicitly change owner of directory-to-be-deleted to workflow user.