### PR TITLE
Cache scores object

### DIFF
--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -10,13 +10,8 @@ library(tsibble)
 library(aws.s3)
 library(covidcast)
 library(stringr)
-library(memoise)
 
 source('./common.R')
-
-# Set application-level caching location.
-shinyOptions(cache = cachem::cache_mem(max_size = 1000 * 1024^2)) # 1 GB cache limit
-cache <- getShinyOption("cache")
 
 # All data is fully loaded from AWS
 DATA_LOADED = FALSE
@@ -218,6 +213,22 @@ ui <- fluidPage(padding=0, title="Forecast Eval Dashboard",
 
 
 # Get and prepare data
+getS3Bucket <- function() {
+  # Connect to AWS s3bucket
+  Sys.setenv("AWS_DEFAULT_REGION" = "us-east-2")
+  s3bucket = tryCatch(
+    {
+      get_bucket(bucket = 'forecast-eval')
+    },
+    error = function(e) {
+      e
+      return(NULL)
+    }
+  )
+  
+  return(s3bucket)
+}
+
 getData <- function(filename, s3bucket){
   if(!is.null(s3bucket)) {
     tryCatch(
@@ -243,51 +254,64 @@ getFallbackData = function(filename) {
   readRDS(path)
 }
 
-getAllData = function(s3bucket, date) {
+getAllData = function(s3bucket) {
   dfStateCases <- getData("score_cards_state_cases.rds", s3bucket)
   dfStateDeaths <- getData("score_cards_state_deaths.rds", s3bucket)
   dfNationCases = getData("score_cards_nation_cases.rds", s3bucket)
   dfNationDeaths = getData("score_cards_nation_deaths.rds", s3bucket)
   dfStateHospitalizations = getData("score_cards_state_hospitalizations.rds", s3bucket)
   dfNationHospitalizations = getData("score_cards_nation_hospitalizations.rds", s3bucket)
-
+  
   # Pick out expected columns only
   covCols = paste0("cov_", COVERAGE_INTERVALS)
   expectedCols = c("ahead", "geo_value", "forecaster", "forecast_date",
                    "data_source", "signal", "target_end_date", "incidence_period",
                    "actual", "wis", "sharpness", "ae", "value_50",
                    covCols)
-
+  
   dfStateCases = dfStateCases %>% select(all_of(expectedCols))
   dfStateDeaths = dfStateDeaths %>% select(all_of(expectedCols))
   dfNationCases = dfNationCases %>% select(all_of(expectedCols))
   dfNationDeaths = dfNationDeaths %>% select(all_of(expectedCols))
   dfStateHospitalizations = dfStateHospitalizations %>% select(all_of(expectedCols))
   dfNationHospitalizations = dfNationHospitalizations %>% select(all_of(expectedCols))
-
+  
   df = rbind(dfStateCases, dfStateDeaths, dfNationCases, dfNationDeaths, dfStateHospitalizations, dfNationHospitalizations)
   df = df %>% rename("10" = cov_10, "20" = cov_20, "30" = cov_30, "40" = cov_40, "50" = cov_50, "60" = cov_60, "70" = cov_70, "80" = cov_80, "90" = cov_90, "95" = cov_95, "98" = cov_98)
-
+  
   return(df)
 }
-getAllData = memoise(getAllData, cache = cache)
 
-getS3Bucket <- function(date, hour) {
-  # Connect to AWS s3bucket
-  Sys.setenv("AWS_DEFAULT_REGION" = "us-east-2")
-  s3bucket = tryCatch(
-    {
-      get_bucket(bucket = 'forecast-eval')
-    },
-    error = function(e) {
-      e
-      return(NULL)
-    }
-  )
+getRecentDataHelper = function() {
+  s3bucket <- getS3Bucket()
+  df <- data.frame()
   
-  return(s3bucket)
+  getRecentData = function() {
+    newS3bucket <- getS3Bucket()
+    
+    s3Contents <- s3bucket[attr(s3bucket, "names", exact=TRUE)]
+    newS3Contents <- newS3bucket[attr(newS3bucket, "names", exact=TRUE)]
+    
+    # Fetch new score data if contents of S3 bucket has changed (including file
+    # names, sizes, and last modified timestamps). Ignores characteristics of
+    # bucket and request, including bucket region, name, content type, request
+    # date, request ID, etc.
+    if ( nrow(df) == 0 || !identical(s3Contents, newS3Contents) ) {
+      # Save new data and new bucket connection info to vars in env of
+      # `getRecentDataHelper`. They persist between calls to `getRecentData` a
+      # la https://stackoverflow.com/questions/1088639/static-variables-in-r
+      s3bucket <<- newS3bucket
+      df <<- getAllData(s3bucket)
+    }
+    
+    return(df)
+  }
+  
+  return(getRecentData)
 }
-getS3Bucket = memoise(getS3Bucket, cache = cache)
+
+getRecentData <- getRecentDataHelper()
+
 
 server <- function(input, output, session) {
   TERRITORIES = c('AS', 'GU', 'MP', 'VI')
@@ -310,13 +334,7 @@ server <- function(input, output, session) {
   HOSP_CURRENT = prevHospWeek[weekdays(prevHospWeek)=='Wednesday']
   
   # Get scores
-  currDate <- as.character(Sys.Date())
-  currHour <- as.integer(format(Sys.time(), format="%H"))
-  hoursBetweenCalls <- 4
-  nHourFloor <- currHour - (currHour %% hoursBetweenCalls)
-  
-  s3bucket <- getS3Bucket(currDate, nHourFloor) # Update every n hours.
-  df = getAllData(s3bucket, currDate)
+  df = getRecentData()
   DATA_LOADED = TRUE
 
   # Prepare input choices

--- a/docker_dashboard/Dockerfile
+++ b/docker_dashboard/Dockerfile
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.source = "https://github.com/cmu-delphi/forecast-
 
 
 ADD docker_dashboard/shiny_server.conf /etc/shiny-server/shiny-server.conf
-RUN install2.r plotly shinyjs tsibble viridis aws.s3 covidcast stringr memoise
+RUN install2.r plotly shinyjs tsibble viridis aws.s3 covidcast stringr
 
 COPY dist/*rds /srv/shiny-server/
 COPY dashboard/* /srv/shiny-server/

--- a/docker_dashboard/Dockerfile
+++ b/docker_dashboard/Dockerfile
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.source = "https://github.com/cmu-delphi/forecast-
 
 
 ADD docker_dashboard/shiny_server.conf /etc/shiny-server/shiny-server.conf
-RUN install2.r plotly shinyjs tsibble viridis aws.s3 covidcast stringr
+RUN install2.r plotly shinyjs tsibble viridis aws.s3 covidcast stringr memoise
 
 COPY dist/*rds /srv/shiny-server/
 COPY dashboard/* /srv/shiny-server/


### PR DESCRIPTION
### Description
Store scores as a global-ish variable (the environment where it's stored is not actually the global environment, but it is a unique environment accessible to all user sessions within the app instance/R session) and only update when the contents of the S3 bucket changes in some way. Reduces the number of times we read the score data, from once per user session to twice a week.

### Changes
- Move data-fetching code out of `server` function.
    -  Functions `getData` and `getFallbackData`
    - Code to get S3 bucket object. Create replacement `getS3Bucket` function.
    - Code to load data from S3 bucket, filter columns, and rename columns. Create replacement `getAllData` function.
- Create `getRecentDataHelper` closure. This function generates a function `getRecentData` to return either stored score data or new score data if the score data has been updated since it was last read. Whether or not it was updated since it was last read is determined by comparing the contents of the stored S3 bucket object, saved at the same time as the stored score data, and a newly-read S3 bucket object. This check happens at the beginning of each user session. `getRecentData` updates score data and the S3 bucket object stored in it's parent (`getRecentDataHelper`) environment.
- Create a global `getRecentData` function from `getRecentDataHelper` so that a single environment is shared by and persists between all calls to `getRecentData`.

### Fixes
Right now, the dashboard is slow to load, especially when multiple people are using it simultaneously. This is because R Shiny is single-threaded by default so user requests are queued and handled one at a time. If there are a bunch of users, the queue is a multiplicative factor longer, exacerbated by requests that take a long time, notably reading score data from the S3 bucket.

### Implications
This change means that score data should only be pulled twice a week, for the first dashboard visitor following each pipeline run and cached for all other users. Locally, sessions using cached data load in about 1 sec, down from about 10 sec.

Since a given instance of the "cache" (scores stored as a variable in memory) is only available within a single R session, it is desirable to have many users share a given app/R session. It's not desirable to have a *huge* server/session pool since the data is loaded (slow step) again for each R session. For example, # R sessions should be << the number of users. (It is possible to store data in an on-disk cache that would be accessible to all app/R sessions, depending on server pool setup, but session load time is slower when reading from disk. It might also be possible to allocate a shared memory region using `mmap`.).

This approach to caching won't extend elegantly to other function calls (e.g. plots), so we'd want to use `memoise` to support those if desired.