### PR TITLE
Fix dashboard docker dependencies: markdown, sf

### DIFF
--- a/docker_dashboard/Dockerfile
+++ b/docker_dashboard/Dockerfile
@@ -1,9 +1,16 @@
 FROM rocker/shiny-verse
 LABEL org.opencontainers.image.source = "https://github.com/cmu-delphi/forecast-eval"
 
-
 ADD docker_dashboard/shiny_server.conf /etc/shiny-server/shiny-server.conf
-RUN install2.r plotly shinyjs tsibble viridis aws.s3 covidcast stringr
+RUN install2.r \
+    plotly \
+    shinyjs \
+    tsibble \
+    viridis \
+    aws.s3 \
+    covidcast \
+    stringr \
+    markdown
 
 COPY dist/*rds /srv/shiny-server/
 COPY dashboard/* /srv/shiny-server/

--- a/docker_dashboard/Dockerfile
+++ b/docker_dashboard/Dockerfile
@@ -1,8 +1,12 @@
 FROM rocker/shiny-verse
 LABEL org.opencontainers.image.source = "https://github.com/cmu-delphi/forecast-eval"
 
+RUN apt-get update && apt-get install -qq -y \
+    libgdal-dev \
+    libudunits2-dev
+
 ADD docker_dashboard/shiny_server.conf /etc/shiny-server/shiny-server.conf
-RUN install2.r \
+RUN install2.r --error \
     plotly \
     shinyjs \
     tsibble \


### PR DESCRIPTION
### Description
Add/fix installation of `markdown` and `sf` R packages for dashboard docker container.

### Changes
- Install `markdown` package.
- Install Linux packages so that `sf` is successfully installed.
- Formatting improvements
- Ask `install2.r` to quit if any packages are not successfully installed, to prevent silent failures.

### Fixes
- App started complaining that `markdown` wasn't installed
- Bonus: `sf` has never been installed successfully