### PR TITLE
Add new 4-week ensemble to list of forecasters to score

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -24,7 +24,7 @@ prediction_cards_filepath = case_when(
 )
 
 forecasters = unique(c(get_covidhub_forecaster_names(designations = c("primary", "secondary")),
-                "COVIDhub-baseline", "COVIDhub-trained_ensemble"))
+                "COVIDhub-baseline", "COVIDhub-trained_ensemble", "COVIDhub-4_week_ensemble"))
 locations = covidHubUtils::hub_locations
 
 # also includes "us", which is national level data


### PR DESCRIPTION
Score new 4-week ensemble, [`COVIDhub-4_week_ensemble`](https://github.com/reichlab/covid19-forecast-hub/blob/6ce7e66bdfc7b10b87322c92f14a8780f52cf798/data-processed/COVIDhub-4_week_ensemble/metadata-COVIDhub-4_week_ensemble.txt#L7), in pipeline. This model is designated as an "other" model and will not be automatically added to the list of forecasters to score.