### PR TITLE
Set dashboard timeout thresholds to reduce disconnects

### DIFF
--- a/docker_dashboard/shiny_server.conf
+++ b/docker_dashboard/shiny_server.conf
@@ -19,5 +19,8 @@ server {
     # Disable some network protocols that are causing issues
     disable_protocols websocket xdr-streaming xhr-streaming iframe-eventsource iframe-htmlfile;
 
+    # Set app timeout threshold to 8 hours
+    app_idle_timeout 28800;
+
   }
 }

--- a/docker_dashboard/shiny_server.conf
+++ b/docker_dashboard/shiny_server.conf
@@ -19,8 +19,9 @@ server {
     # Disable some network protocols that are causing issues
     disable_protocols websocket xdr-streaming xhr-streaming iframe-eventsource iframe-htmlfile;
 
-    # Set app timeout threshold to 8 hours
+    # Set app timeout threshold to 8 hours, and user session timeout to 4 hours
     app_idle_timeout 28800;
+    app_session_timeout 14400;
 
   }
 }


### PR DESCRIPTION
### Description
Explicitly set various dashboard timeout thresholds.

### Changes
- Set app (R session) timeout to 8 hours, up from [default of 5 seconds](https://docs.rstudio.com/shiny-server/#application-timeouts).
- Set each app instance (user session) timeout to 4 hours, down from [default of never](https://docs.rstudio.com/shiny-server/#session-timeouts).

Note: I am unable to get the `app_session_timeout` key (and other keys restricted to Shiny Server Pro) to be recognized locally. However, assuming we have Shiny Server Pro, this should work in staging and prod.

### Fixes
Decrease the rate of app disconnects.

Letting a given app session last longer improves the caching behavior from #169. Since the data cache is stored in memory, if the session closes we need to reload and re-cache the data.