### PR TITLE
Re-enable scaleByBaseline for hospitalizations

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -243,7 +243,7 @@ server <- function(input, output, session) {
     filteredScoreDf <- filteredScoreDf[c("Forecaster", "Forecast_Date", "Week_End_Date", "Score", "ahead")]
     filteredScoreDf <- filteredScoreDf %>% mutate(across(where(is.numeric), ~ round(., 2)))
     if (input$scoreType != "coverage") {
-      if (input$scaleByBaseline && input$targetVariable != "Hospitalizations") {
+      if (input$scaleByBaseline) {
         baselineDf <- filteredScoreDf %>% filter(Forecaster %in% "COVIDhub-baseline")
         filteredScoreDfMerged <- merge(filteredScoreDf, baselineDf, by = c("Week_End_Date", "ahead"))
         # Scaling score by baseline forecaster


### PR DESCRIPTION
Now that hospitalizations have been added to the CovidHub baseline forecaster ([as of Sep 21](https://delphi-org.slack.com/archives/C01H63T0QE7/p1632272093047200)), enable scaleByBaseline feature for hospitalizations. Reverts #148.