### PR TITLE
Revert app session timeout

### DIFF
--- a/devops/shiny_server.conf
+++ b/devops/shiny_server.conf
@@ -22,8 +22,8 @@ server {
     # Disable some network protocols that are causing issues
     # disable_protocols websocket xdr-streaming xhr-streaming iframe-eventsource iframe-htmlfile;
 
-    # Set app timeout threshold to 8 hours
-    app_idle_timeout 28800;
+    # Set app timeout threshold to 4 hours
+    app_idle_timeout 14400;
 
   }
 }

--- a/devops/shiny_server.conf
+++ b/devops/shiny_server.conf
@@ -22,9 +22,8 @@ server {
     # Disable some network protocols that are causing issues
     # disable_protocols websocket xdr-streaming xhr-streaming iframe-eventsource iframe-htmlfile;
 
-    # Set app timeout threshold to 8 hours, and user session timeout to 4 hours
+    # Set app timeout threshold to 8 hours
     app_idle_timeout 28800;
-    app_session_timeout 14400;
 
   }
 }


### PR DESCRIPTION
`app_session_timeout` is not recognized as a valid setting, so remove. Decrease `app_idle_timeout` so it shuts down occasionally, implicitly killing any inactive user sessions.