### PR TITLE
Match docker port mapping to shiny export port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
-	docker run --rm -p 3838:3838 ghcr.io/cmu-delphi/forecast-eval:latest
+	docker run --rm -p 3838:80 ghcr.io/cmu-delphi/forecast-eval:latest


### PR DESCRIPTION
#171 changed Shiny to listen on port 80. Update Makefile to match.