### PR TITLE
fix: use remote google font

### DIFF
--- a/app/R/delphiLayout.R
+++ b/app/R/delphiLayout.R
@@ -49,7 +49,7 @@ delphiLayoutUI <- function(id = "delphi-root", title = "My App",
                            sidebar = list(),
                            main = list()) {
   ns <- shiny::NS(id)
-  font <- bslib::font_google("Open Sans", local = TRUE)
+  font <- bslib::font_google("Open Sans", local = FALSE)
   div(
     id = id,
     class = "delphi-root",


### PR DESCRIPTION
since our containers don't have internet access in production the font loading files, since it tries to download them first. -> serve them directly from google instead