### PR TITLE
Display scaleByBaseline checkbox for hospitalizations

### DIFF
--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -88,7 +88,7 @@ ui <- fluidPage(padding=0, title="Forecast Eval Dashboard",
                                "Log Scale",
                                value = FALSE,
                              )),
-            conditionalPanel(condition = "input.scoreType != 'coverage' && input.targetVariable != 'Hospitalizations'",
+            conditionalPanel(condition = "input.scoreType != 'coverage'",
                              checkboxInput(
                                "scaleByBaseline",
                                "Scale by Baseline Forecaster",


### PR DESCRIPTION
Followup to #180. Display the checkbox to allow user to toggle scaleByBaseline on and off.