### PR TITLE
Cache covidcast pulls

### DIFF
--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -10,6 +10,7 @@ library(tsibble)
 library(aws.s3)
 library(covidcast)
 library(stringr)
+library(memoise)
 
 source('./common.R')
 

--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -14,6 +14,18 @@ library(memoise)
 
 source('./common.R')
 
+# Set application-level caching location. Stores up to 1GB of caches. Removes
+# least recently used objects first.
+shinyOptions(cache = cachem::cache_mem(max_size = 1000 * 1024^2, evict="lru"))
+cache <- getShinyOption("cache")
+
+# Since covidcast data updates about once a day. Add date arg to
+# covidcast_signal so caches aren't used after that.
+covidcast_signal_mem <- function(..., date=Sys.Date()) {
+  return(covidcast_signal(...))
+}
+covidcast_signal_mem <- memoise(covidcast_signal_mem, cache = cache)
+
 # All data is fully loaded from AWS
 DATA_LOADED = FALSE
 
@@ -916,7 +928,7 @@ server <- function(input, output, session) {
       fetchDate = as.Date(input$asOf) + 1
 
       # Covidcast API call
-      asOfTruthData = covidcast_signal(data_source = dataSource, signal = targetSignal,
+      asOfTruthData = covidcast_signal_mem(data_source = dataSource, signal = targetSignal,
                                        start_day = "2020-02-15", end_day = fetchDate,
                                        as_of = fetchDate,
                                        geo_type = location)

--- a/docker_dashboard/Dockerfile
+++ b/docker_dashboard/Dockerfile
@@ -14,7 +14,8 @@ RUN install2.r --error \
     aws.s3 \
     covidcast \
     stringr \
-    markdown
+    markdown \
+    memoise
 
 COPY dist/*rds /srv/shiny-server/
 COPY dashboard/* /srv/shiny-server/


### PR DESCRIPTION
Cache `covidcast_signal()` requests to speed up page loading. Define wrapper with additional date arg so that caches are recreated every day with updates to covidcast data.