### PR TITLE
Drop unused locations upfront

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -111,13 +111,7 @@ server <- function(input, output, session) {
   # CREATE MAIN PLOT
   ##################
   summaryPlot <- function(colorSeed = 100, reRenderTruth = FALSE, asOfData = NULL) {
-    filteredScoreDf <- filterScoreDf()
-    if (!SUMMARIZING_OVER_ALL_LOCATIONS()) {
-      filteredScoreDf <- filter(filteredScoreDf, geo_value == tolower(input$location))
-    } else if (SUMMARIZING_OVER_ALL_LOCATIONS()) {
-      filteredScoreDf <- filteredScoreDf %>% filter(geo_value != "us")
-    }
-
+    filteredScoreDf <- filterScoreDf(isolate(SUMMARIZING_OVER_ALL_LOCATIONS()))
     dfWithForecasts <- NULL
     if (input$showForecasts) {
       dfWithForecasts <- filteredScoreDf
@@ -411,8 +405,8 @@ server <- function(input, output, session) {
     summaryPlot()
   })
 
-  # Filter scoring df by inputs chosen (targetVariable, forecasters, aheads)
-  filterScoreDf <- function() {
+  # Filter scoring df by inputs chosen (targetVariable, forecasters, aheads, location)
+  filterScoreDf <- function(summarize_over_all_locations) {
     signalFilter <- CASE_FILTER
     if (input$targetVariable == "Deaths") {
       signalFilter <- DEATH_FILTER
@@ -446,6 +440,13 @@ server <- function(input, output, session) {
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)
+
+    if (!summarize_over_all_locations) {
+      filteredScoreDf <- filter(filteredScoreDf, geo_value == tolower(input$location))
+    } else if (summarize_over_all_locations) {
+      filteredScoreDf <- filteredScoreDf %>% filter(geo_value != "us")
+    }
+
     return(filteredScoreDf)
   }
 


### PR DESCRIPTION
Certain forecasters, like `Imperial-ensemble2`, only predict for select locations. This interferes with some of our as-of data selection logic and creates in the final score data an "NA" forecaster with "NA" ahead (hence the second facet of the plot) that causes plot shenanigans. Prevent by removing invalid locations (e.g. "US" if "AK" is selected) during initial filtering of score data, before as-of data is created and joined on.

Closes #160. Also interacts with #161.