### PR TITLE
Display full names for states and territories

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -35,6 +35,8 @@ MIN_AVAIL_HOSP_AS_OF_DATE <- as.Date("2020-11-11")
 MIN_AVAIL_TERRITORY_AS_OF_DATE <- as.Date("2021-02-10")
 
 TERRITORIES <- c("AS", "GU", "MP", "VI")
+STATE_ABB <- c(state.abb, TERRITORIES, "PR", "DC")
+STATE_NAME <- c(state.name, "American Samoa", "Guam", "Northern Mariana Islands", "US Virgin Islands", "Puerto Rico", "District of Columbia")
 
 resolveCurrentCasesDeathDay <- function() {
   # Get most recent target end date

--- a/app/server.R
+++ b/app/server.R
@@ -38,9 +38,18 @@ updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices
 updateLocationChoices <- function(session, df, targetVariable, forecasterChoices, locationInput) {
   df <- df %>% filter(forecaster %in% forecasterChoices)
   locationChoices <- unique(toupper(df$geo_value))
+
   # Move US to front of list
   locationChoices <- locationChoices[c(length(locationChoices), seq_len(length(locationChoices) - 1))]
+  # Add totaled states option to front of list
   locationChoices <- c(TOTAL_LOCATIONS, locationChoices)
+
+  # Display full names for subset of locations
+  longnames <- STATE_NAME[match(locationChoices, STATE_ABB)]
+  names(locationChoices) <- paste(locationChoices, "-", longnames)
+  unmatched <- which(is.na(longnames))
+  names(locationChoices)[unmatched] <- locationChoices[unmatched]
+
   # Ensure previously selected options are still allowed
   if (locationInput %in% locationChoices) {
     selectedLocation <- locationInput


### PR DESCRIPTION
Closes #30. The original issue only asks for full names for territories, but having full state names makes for easier skimming. Displayed in dropdown as "AK - Alaska", etc.