### PR TITLE
Suppress legend labels

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -316,8 +316,7 @@ server <- function(input, output, session) {
       facet_wrap(~ahead, ncol = 1) +
       scale_color_manual(values = colorPalette) +
       theme_bw() +
-      theme(panel.spacing = unit(0.5, "lines")) +
-      theme(legend.title = element_blank())
+      theme(panel.spacing = unit(0.5, "lines"))
 
     if (input$scoreType == "coverage") {
       p <- p + geom_hline(yintercept = .01 * as.integer(input$coverageInterval))
@@ -331,7 +330,7 @@ server <- function(input, output, session) {
     finalPlot <-
       ggplotly(p, tooltip = c("x", "y", "shape", "label"), height = plotHeight) %>%
       layout(
-        legend = list(orientation = "h", y = -0.1),
+        legend = list(orientation = "h", y = -0.1, title=list(text = NULL)),
         margin = list(t = 90),
         hovermode = "x unified",
         xaxis = list(
@@ -377,8 +376,7 @@ server <- function(input, output, session) {
       scale_y_continuous(limits = c(0, NA), labels = scales::comma) +
       scale_x_date(date_labels = "%b %Y") +
       scale_color_manual(values = colorPalette) +
-      theme_bw() +
-      theme(legend.title = element_blank())
+      theme_bw()
 
     if (hasAsOfData) {
       finalPlot <- finalPlot +
@@ -396,7 +394,10 @@ server <- function(input, output, session) {
         geom_point(aes(y = Reported_Incidence))
     }
     finalPlot <- ggplotly(finalPlot, tooltip = c("shape", "x", "y")) %>%
-      layout(hovermode = "x unified", legend = list(orientation = "h", y = -0.1)) %>%
+      layout(
+        hovermode = "x unified",
+        legend = list(orientation = "h", y = -0.1, title=list(text = NULL))
+      ) %>%
       config(displayModeBar = F)
     # Remove the extra grouping from the legend: "(___,1)"
     for (i in seq_along(finalPlot$x$data)) {

--- a/app/server.R
+++ b/app/server.R
@@ -328,9 +328,10 @@ server <- function(input, output, session) {
     }
     plotHeight <- 550 + (length(input$aheads) - 1) * 100
     finalPlot <-
-      ggplotly(p, tooltip = c("x", "y", "shape", "label"), height = plotHeight) %>%
+      ggplotly(p, tooltip = c("x", "y", "shape", "label")) %>%
       layout(
-        legend = list(orientation = "h", y = -0.1, title=list(text = NULL)),
+        height = plotHeight,
+        legend = list(orientation = "h", y = -0.1, title = list(text=NULL)),
         margin = list(t = 90),
         hovermode = "x unified",
         xaxis = list(
@@ -396,7 +397,7 @@ server <- function(input, output, session) {
     finalPlot <- ggplotly(finalPlot, tooltip = c("shape", "x", "y")) %>%
       layout(
         hovermode = "x unified",
-        legend = list(orientation = "h", y = -0.1, title=list(text = NULL))
+        legend = list(orientation = "h", y = -0.1, title = list(text=NULL))
       ) %>%
       config(displayModeBar = F)
     # Remove the extra grouping from the legend: "(___,1)"

--- a/app/server.R
+++ b/app/server.R
@@ -331,7 +331,7 @@ server <- function(input, output, session) {
       ggplotly(p, tooltip = c("x", "y", "shape", "label")) %>%
       layout(
         height = plotHeight,
-        legend = list(orientation = "h", y = -0.1, title = list(text=NULL)),
+        legend = list(orientation = "h", y = -0.1, title = list(text = NULL)),
         margin = list(t = 90),
         hovermode = "x unified",
         xaxis = list(
@@ -397,7 +397,7 @@ server <- function(input, output, session) {
     finalPlot <- ggplotly(finalPlot, tooltip = c("shape", "x", "y")) %>%
       layout(
         hovermode = "x unified",
-        legend = list(orientation = "h", y = -0.1, title = list(text=NULL))
+        legend = list(orientation = "h", y = -0.1, title = list(text = NULL))
       ) %>%
       config(displayModeBar = F)
     # Remove the extra grouping from the legend: "(___,1)"


### PR DESCRIPTION
### Description
Move legend title suppression and plot height to `plotly::layout` section to make sure the settings are applied correctly.

`theme(legend.title = element_blank())` in calls to `ggplot` should prevent the legend from being labelled, but after converting to a `plotly` plot using `ggplotly`, the legend titles reappear and, for the score plot, are doubled. This seems to be related to a package update, although I haven't been able to reproduce the working version. For example, the public dashboard running off of a 2-month old build displays correctly, but a new build off of `main` exhibits the problem.

Since `plotly` has a history of incorrectly displaying `ggplot` settings, just put legend title suppression into `plotly` settings directly.

Closes #209.

### Changes
- `server.R`: Set plot `height` and `legend.title` in `plotly::layout`.