### PR TITLE
Force scoring pipeline to use old stable covidcast image

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -1,2 +1,2 @@
 # docker image for setting up an R environment
-FROM ghcr.io/cmu-delphi/covidcast:latest
+FROM ghcr.io/cmu-delphi/covidcast@sha256:5c1324d2a9b67e557214ad7e1d5effee7229083d46e3c405a63505b8a3a6427b


### PR DESCRIPTION
Some models are being dropped during scoring or aren't included for the full date span they should be. This seems to be related to a newer docker image (even though it shouldn't have any changed code), so revert to previous version that was known to work.

Related to #215.