### PR TITLE
Revert "Force scoring pipeline to use old stable covidcast image"

### DIFF
--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -1,2 +1,2 @@
 # docker image for setting up an R environment
-FROM ghcr.io/cmu-delphi/covidcast@sha256:5c1324d2a9b67e557214ad7e1d5effee7229083d46e3c405a63505b8a3a6427b
+FROM ghcr.io/cmu-delphi/covidcast:latest


### PR DESCRIPTION
Now that `arrow` is pinned to a working version, revert cmu-delphi/forecast-eval#216.