### PR TITLE
Increase self-hosted workflow timeout to 24 hours

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -16,8 +16,8 @@ jobs:
   deploy:
     # The type of runner that the job will run on
     runs-on: self-hosted
-    # Time out after 12 hours.
-    timeout-minutes: 720
+    # Time out after 24 hours.
+    timeout-minutes: 1440
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -16,6 +16,8 @@ jobs:
   deploy:
     # The type of runner that the job will run on
     runs-on: self-hosted
+    # Time out after 12 hours.
+    timeout-minutes: 720
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
so that the occasional mysteriously long run can still complete.

Self-hosted actions can run for up to 72 hours before being automatically canceled. The default timeout is 6 hours, so we need to explicitly increase that.