### PR TITLE
Display warnings as they happen for easier debugging

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -4,6 +4,8 @@ library("dplyr")
 library("evalcast")
 library("lubridate")
 
+options(warn = 1)
+
 option_list <- list(
   make_option(
     c("-d", "--dir"),


### PR DESCRIPTION
Change warning option to 1, so that warnings are printed as they occur.