### PR TITLE
Warn if missing any forecasters

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -4,6 +4,12 @@ library("dplyr")
 library("evalcast")
 library("lubridate")
 
+# TODO: Contains fixed versions of WIS component metrics, to be ported over to evalcast
+# Redefines overprediction, underprediction and sharpness
+source("error_measures.R")
+source("score.R")
+source("utils.R")
+
 options(warn = 1)
 
 option_list <- list(
@@ -94,9 +100,6 @@ coverage_functions <- sapply(
 )
 names(coverage_functions) <- cov_names
 
-# TODO: Contains fixed versions of WIS component metrics, to be ported over to evalcast
-# Redefines overprediction, underprediction and sharpness
-source("error_measures.R")
 
 err_measures <- c(
   wis = weighted_interval_score,
@@ -117,13 +120,18 @@ state_predictions <- predictions_cards %>% filter(geo_value != "us")
 rm(predictions_cards)
 gc()
 
+## Check if nation and state predictions objects contain the expected forecasters
+for (signal_name in signals) {
+  check_for_missing_forecasters(nation_predictions, forecasters, "nation", signal_name, opt$dir)
+  check_for_missing_forecasters(state_predictions, forecasters, "state", signal_name, opt$dir)
+}
+
 print("Evaluating state forecasts")
 state_scores <- evaluate_covid_predictions(state_predictions,
   err_measures,
   geo_type = "state"
 )
 
-source("score.R")
 if ("confirmed_incidence_num" %in% unique(state_scores$signal)) {
   print("Saving state confirmed incidence...")
   save_score_cards(state_scores, "state",

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -23,6 +23,9 @@ prediction_cards_filepath <- case_when(
   TRUE ~ prediction_cards_filename
 )
 
+# Note: CDDEP-ABM is not longer available and causes some warnings when trying
+# to download its data. Defer to `get_covidhub_forecaster_names` and underlying
+# Reich Lab utilities as to which forecasters to include.
 forecasters <- unique(c(
   get_covidhub_forecaster_names(designations = c("primary", "secondary")),
   "COVIDhub-baseline", "COVIDhub-trained_ensemble", "COVIDhub-4_week_ensemble"

--- a/Report/score.R
+++ b/Report/score.R
@@ -1,6 +1,24 @@
 library("dplyr")
 library("assertthat")
 
+type_map <- list(
+  "confirmed_incidence_num" = "cases",
+  "deaths_incidence_num" = "deaths",
+  "confirmed_admissions_covid_1d" = "hospitalizations"
+)
+
+generate_score_card_file_path <- function(geo_type, signal_name, output_dir) {
+  sig_suffix <- type_map[[signal_name]]
+  output_file_name <- file.path(
+    output_dir,
+    paste0(
+      "score_cards_", geo_type, "_",
+      sig_suffix, ".rds"
+    )
+  )
+  return(output_file_name)
+}
+
 save_score_cards <- function(score_card, geo_type = c("state", "nation"),
                              signal_name = c(
                                "confirmed_incidence_num",

--- a/Report/utils.R
+++ b/Report/utils.R
@@ -4,29 +4,30 @@ check_for_missing_forecasters <- function(predictions_cards, forecasters_list, g
     filter(signal == signal_name) %>%
     distinct(forecaster) %>%
     pull()
-  current_run_forecasters <- predictions_cards %>% 
+  current_run_forecasters <- predictions_cards %>%
     filter(signal == signal_name) %>%
     distinct(forecaster) %>%
     pull()
-  
-  # Find forecasters we asked for that weren't produced. This just prints a 
+
+  # Find forecasters we asked for that weren't produced. This just prints a
   # message because we already know that some forecasters, like CDDEP-ABM,
   # aren't available.
   missing_forecasters <- setdiff(forecasters_list, current_run_forecasters)
   if (length(missing_forecasters) != 0) {
     print(paste(
-      paste(missing_forecasters, collapse = ", "), 
-      "were asked for but not generated")
-    )
+      paste(missing_forecasters, collapse = ", "),
+      "were asked for but not generated"
+    ))
   }
-  
+
   # Find forecasters included in the previous run (based on which ones are
   # included in the relevant score file downloaded from the S3 bucket) that are
   # not in the current run.
   missing_forecasters <- setdiff(previous_run_forecasters, current_run_forecasters)
   assert_that(length(missing_forecasters) == 0,
-         msg = paste(
-           paste(missing_forecasters, collapse = ", "),
-           "were available in the most recent pipeline run but are no longer present")
+    msg = paste(
+      paste(missing_forecasters, collapse = ", "),
+      "were available in the most recent pipeline run but are no longer present"
+    )
   )
 }

--- a/Report/utils.R
+++ b/Report/utils.R
@@ -1,0 +1,32 @@
+check_for_missing_forecasters <- function(predictions_cards, forecasters_list, geo_type, signal_name, output_dir) {
+  output_file_name <- generate_score_card_file_path(geo_type, signal_name, output_dir)
+  previous_run_forecasters <- readRDS(output_file_name) %>%
+    filter(signal == signal_name) %>%
+    distinct(forecaster) %>%
+    pull()
+  current_run_forecasters <- predictions_cards %>% 
+    filter(signal == signal_name) %>%
+    distinct(forecaster) %>%
+    pull()
+  
+  # Find forecasters we asked for that weren't produced. This just prints a 
+  # message because we already know that some forecasters, like CDDEP-ABM,
+  # aren't available.
+  missing_forecasters <- setdiff(forecasters_list, current_run_forecasters)
+  if (length(missing_forecasters) != 0) {
+    print(paste(
+      paste(missing_forecasters, collapse = ", "), 
+      "were asked for but not generated")
+    )
+  }
+  
+  # Find forecasters included in the previous run (based on which ones are
+  # included in the relevant score file downloaded from the S3 bucket) that are
+  # not in the current run.
+  missing_forecasters <- setdiff(previous_run_forecasters, current_run_forecasters)
+  assert_that(length(missing_forecasters) == 0,
+         msg = paste(
+           paste(missing_forecasters, collapse = ", "),
+           "were available in the most recent pipeline run but are no longer present")
+  )
+}

--- a/Report/utils.R
+++ b/Report/utils.R
@@ -9,17 +9,6 @@ check_for_missing_forecasters <- function(predictions_cards, forecasters_list, g
     distinct(forecaster) %>%
     pull()
 
-  # Find forecasters we asked for that weren't produced. This just prints a
-  # message because we already know that some forecasters, like CDDEP-ABM,
-  # aren't available.
-  missing_forecasters <- setdiff(forecasters_list, current_run_forecasters)
-  if (length(missing_forecasters) != 0) {
-    print(paste(
-      paste(missing_forecasters, collapse = ", "),
-      "were asked for but not generated"
-    ))
-  }
-
   # Find forecasters included in the previous run (based on which ones are
   # included in the relevant score file downloaded from the S3 bucket) that are
   # not in the current run.
@@ -27,7 +16,8 @@ check_for_missing_forecasters <- function(predictions_cards, forecasters_list, g
   assert_that(length(missing_forecasters) == 0,
     msg = paste(
       paste(missing_forecasters, collapse = ", "),
-      "were available in the most recent pipeline run but are no longer present"
+      "were available in the most recent pipeline run but are no longer present for",
+      geo_type, signal_name
     )
   )
 }


### PR DESCRIPTION
### Description
Check if all requested forecasters were generated. Check if all forecasters from previous run were generated again.

### Changes
- `create_reports.R`
- Add `utils.R`
- `score.R` has a new function to generate output file names.