### PR TITLE
Fix "No <signal> available at the <geo> level" error always being raised

### DIFF
--- a/Report/score.R
+++ b/Report/score.R
@@ -51,7 +51,7 @@ save_score_cards <- function(score_card, geo_type = c("state", "nation"),
 }
 
 save_score_cards_wrapper <- function(score_card, geo_type, signal_name, output_dir) {
-  if (signal_name %in% unique(score_card["signal"])) {
+  if (signal_name %in% unique(score_card[["signal"]])) {
     print(paste("Saving", geo_type, type_map[[signal_name]], "..."))
     save_score_cards(score_card, geo_type,
       signal_name = signal_name, output_dir = output_dir


### PR DESCRIPTION
Add brackets so signal col is returned as character vector not dataframe. If the "signal" col is returned as a dataframe, we can't check if `signal_name` appears in it using `%in%` so we always fail to save score cards.