### PR TITLE
Have pipeline save datetime of run + keep predictions for future dates

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -175,5 +175,5 @@ if (length(save_score_errors) > 0) {
   stop(paste(save_score_errors, collapse = "\n"))
 }
 
-saveRDS(data.frame(datetime = c(data_pull_timestamp)), file=file.path(output_dir, "datetime_created_utc.rds"))
+saveRDS(data.frame(datetime = c(data_pull_timestamp)), file = file.path(output_dir, "datetime_created_utc.rds"))
 print("Done")

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -58,6 +58,7 @@ signals <- c(
   "confirmed_admissions_covid_1d"
 )
 
+data_pull_timestamp <- now(tzone = "UTC")
 predictions_cards <- get_covidhub_predictions(forecasters,
   signal = signals,
   ahead = 1:28,
@@ -174,4 +175,5 @@ if (length(save_score_errors) > 0) {
   stop(paste(save_score_errors, collapse = "\n"))
 }
 
+saveRDS(data.frame(datetime = c(data_pull_timestamp)), file=file.path(output_dir, "datetime_created_utc.rds"))
 print("Done")

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -70,9 +70,9 @@ predictions_cards <- get_covidhub_predictions(forecasters,
 
 options(warn = 0)
 
+# Includes predictions for future dates, which will not be scored.
 predictions_cards <- predictions_cards %>%
-  filter(!is.na(target_end_date)) %>%
-  filter(target_end_date < today())
+  filter(!is.na(target_end_date))
 
 # For hospitalizations, drop all US territories except Puerto Rico and the
 # Virgin Islands; HHS does not report data for any territories except PR and VI.


### PR DESCRIPTION
### Description
Have pipeline save datetime in UTC to .RDS format along with score files. This will be useful in future pipeline and dashboard improvements. Since it is in .RDS format and saved to `dist`, it gets uploaded to the S3 bucket using the [existing `make` target](https://github.com/cmu-delphi/forecast-eval/blob/d2e216e1dbd075f617099d1d7a92ebb4668cec2d/Makefile#L30).

Also remove the filter that drops predictions made for dates in the future. We want to be able to display these in the dashboard. Since these predictions have no associated truth data, they are unscored and do not appear in the dashboard as-is.

## Changes
- `Report/create_reports.R`