### PR TITLE
Support showing predictions for future dates in the dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ r_build:
 %.rds: dist
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@
 
-pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds
+pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds
 
 dist:
 	mkdir $@

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -175,5 +175,5 @@ if (length(save_score_errors) > 0) {
   stop(paste(save_score_errors, collapse = "\n"))
 }
 
-saveRDS(data.frame(datetime = c(data_pull_timestamp)), file=file.path(output_dir, "datetime_created_utc.rds"))
+saveRDS(data.frame(datetime = c(data_pull_timestamp)), file = file.path(output_dir, "datetime_created_utc.rds"))
 print("Done")

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -69,9 +69,9 @@ predictions_cards <- get_covidhub_predictions(forecasters,
 
 options(warn = 0)
 
+# Includes predictions for future dates, which will not be scored.
 predictions_cards <- predictions_cards %>%
-  filter(!is.na(target_end_date)) %>%
-  filter(target_end_date < today())
+  filter(!is.na(target_end_date))
 
 # For hospitalizations, drop all US territories except Puerto Rico and the
 # Virgin Islands; HHS does not report data for any territories except PR and VI.

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -58,6 +58,7 @@ signals <- c(
   "confirmed_admissions_covid_1d"
 )
 
+data_pull_timestamp <- now(tzone = "UTC")
 predictions_cards <- get_covidhub_predictions(forecasters,
   signal = signals,
   ahead = 1:28,
@@ -174,4 +175,5 @@ if (length(save_score_errors) > 0) {
   stop(paste(save_score_errors, collapse = "\n"))
 }
 
+saveRDS(data.frame(datetime = c(data_pull_timestamp)), file=file.path(output_dir, "datetime_created_utc.rds"))
 print("Done")

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -60,6 +60,13 @@ getFallbackData <- function(filename) {
   readRDS(path)
 }
 
+
+getCreationDate <- function(loadFile) {
+  dataCreationDate <- loadFile("datetime_created_utc.rds")
+  return(dataCreationDate %>% pull(datetime) %>% as.Date())
+}
+
+
 getAllData <- function(loadFile) {
   dfStateCases <- loadFile("score_cards_state_cases.rds")
   dfStateDeaths <- loadFile("score_cards_state_deaths.rds")
@@ -100,6 +107,7 @@ getAllData <- function(loadFile) {
 createS3DataLoader <- function() {
   s3bucket <- getS3Bucket()
   df <- data.frame()
+  dataCreationDate <- as.Date(NA)
 
   getRecentData <- function() {
     newS3bucket <- getS3Bucket()
@@ -117,9 +125,10 @@ createS3DataLoader <- function() {
       # la https://stackoverflow.com/questions/1088639/static-variables-in-r
       s3bucket <<- newS3bucket
       df <<- getAllData(createS3DataFactory(s3bucket))
+      dataCreationDate <<- getCreationDate(createS3DataFactory(s3bucket))
     }
 
-    return(df)
+    return(list(df = df, dataCreationDate = dataCreationDate))
   }
 
   return(getRecentData)

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -13,9 +13,9 @@ renameScoreCol <- function(filteredScoreDf, scoreType, coverageInterval) {
 }
 
 
-filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE) {
+filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE, filterDate) {
   locationsIntersect <- list()
-  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) && target_end_date < today()))
+  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) && target_end_date < filterDate))
   # Create df with col for all locations across each unique date, ahead and forecaster combo
   locationDf <- filteredScoreDf %>%
     group_by(forecaster, target_end_date, ahead) %>%

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -15,7 +15,7 @@ renameScoreCol <- function(filteredScoreDf, scoreType, coverageInterval) {
 
 filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE) {
   locationsIntersect <- list()
-  filteredScoreDf <- filteredScoreDf %>% filter(!is.na(Score))
+  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) && target_end_date < today()))
   # Create df with col for all locations across each unique date, ahead and forecaster combo
   locationDf <- filteredScoreDf %>%
     group_by(forecaster, target_end_date, ahead) %>%

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -15,7 +15,7 @@ renameScoreCol <- function(filteredScoreDf, scoreType, coverageInterval) {
 
 filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE, filterDate) {
   locationsIntersect <- list()
-  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) && target_end_date < filterDate))
+  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) & target_end_date < filterDate))
   # Create df with col for all locations across each unique date, ahead and forecaster combo
   locationDf <- filteredScoreDf %>%
     group_by(forecaster, target_end_date, ahead) %>%

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -15,7 +15,7 @@ renameScoreCol <- function(filteredScoreDf, scoreType, coverageInterval) {
 
 filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE, filterDate) {
   locationsIntersect <- list()
-  filteredScoreDf <- filteredScoreDf %>% filter(!(is.na(Score) & target_end_date < filterDate))
+  filteredScoreDf <- filteredScoreDf %>% filter(!is.na(Score) | target_end_date >= filterDate)
   # Create df with col for all locations across each unique date, ahead and forecaster combo
   locationDf <- filteredScoreDf %>%
     group_by(forecaster, target_end_date, ahead) %>%

--- a/app/server.R
+++ b/app/server.R
@@ -405,7 +405,7 @@ server <- function(input, output, session) {
         as.Date(input$asOf) + 7 * 4,
         as.Date(NA)
       )
-      
+
       finalPlot <- finalPlot +
         geom_line(aes(y = Quantile_50, color = Forecaster, shape = Forecaster)) +
         geom_point(aes(y = Quantile_50, color = Forecaster, shape = Forecaster)) +

--- a/app/server.R
+++ b/app/server.R
@@ -453,16 +453,15 @@ server <- function(input, output, session) {
       # Only show WIS or Sharpness for forecasts that have all intervals or are for future dates
       filteredScoreDf <- filteredScoreDf %>%
         filter((
-            !is.na(`50`) &
+          !is.na(`50`) &
             !is.na(`80`) &
             !is.na(`95`)
-          ) |
-            target_end_date >= dataCreationDate
-        )
+        ) |
+          target_end_date >= dataCreationDate)
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
           filter((
-              !is.na(`10`) &
+            !is.na(`10`) &
               !is.na(`20`) &
               !is.na(`30`) &
               !is.na(`40`) &
@@ -470,9 +469,8 @@ server <- function(input, output, session) {
               !is.na(`70`) &
               !is.na(`90`) &
               !is.na(`98`)
-            ) |
-              target_end_date >= dataCreationDate
-          )
+          ) |
+            target_end_date >= dataCreationDate)
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)

--- a/app/server.R
+++ b/app/server.R
@@ -405,7 +405,9 @@ server <- function(input, output, session) {
         as.Date(input$asOf) + 7 * 4,
         as.Date(NA)
       )
+      
       finalPlot <- finalPlot +
+        geom_line(aes(y = Quantile_50, color = Forecaster, shape = Forecaster)) +
         geom_point(aes(y = Quantile_50, color = Forecaster, shape = Forecaster)) +
         scale_x_date(limits = c(as.Date(NA), maxLim), date_labels = "%b %Y")
     }
@@ -418,11 +420,7 @@ server <- function(input, output, session) {
     # Remove the extra grouping from the legend: "(___,1)"
     for (i in seq_along(finalPlot$x$data)) {
       if (!is.null(finalPlot$x$data[[i]]$name)) {
-        if (endsWith(finalPlot$x$data[[i]]$name, ",1)") && finalPlot$x$data[[i]]$mode != "lines+markers") {
-          finalPlot$x$data[[i]]$showlegend <- FALSE
-        }
         finalPlot$x$data[[i]]$name <- gsub("\\(", "", stringr::str_split(finalPlot$x$data[[i]]$name, ",")[[1]][1])
-        finalPlot$x$data[[i]]$mode <- "lines+markers"
       }
     }
     return(finalPlot)

--- a/app/server.R
+++ b/app/server.R
@@ -448,20 +448,20 @@ server <- function(input, output, session) {
       # Only show WIS or Sharpness for forecasts that have all intervals unless they are for future dates
       filteredScoreDf <- filteredScoreDf %>%
         filter(!(is.na(`50`) &&
-               is.na(`80`) &&
-               is.na(`95`) &&
-               target_end_date < today()))
+          is.na(`80`) &&
+          is.na(`95`) &&
+          target_end_date < today()))
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
           filter(!(is.na(`10`) &&
-                 is.na(`20`) &&
-                 is.na(`30`) &&
-                 is.na(`40`) &&
-                 is.na(`60`) &&
-                 is.na(`70`) &&
-                 is.na(`90`) &&
-                 is.na(`98`) &&
-                 target_end_date < today()))
+            is.na(`20`) &&
+            is.na(`30`) &&
+            is.na(`40`) &&
+            is.na(`60`) &&
+            is.na(`70`) &&
+            is.na(`90`) &&
+            is.na(`98`) &&
+            target_end_date < today()))
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)

--- a/app/server.R
+++ b/app/server.R
@@ -450,27 +450,29 @@ server <- function(input, output, session) {
       filteredScoreDf <- filterHospitalizationsAheads(filteredScoreDf)
     }
     if (input$scoreType == "wis" || input$scoreType == "sharpness") {
-      # Only show WIS or Sharpness for forecasts that have all intervals unless they are for future dates
+      # Only show WIS or Sharpness for forecasts that have all intervals or are for future dates
       filteredScoreDf <- filteredScoreDf %>%
         filter((
             !is.na(`50`) &
             !is.na(`80`) &
             !is.na(`95`)
           ) |
-            target_end_date >= dataCreationDate)
+            target_end_date >= dataCreationDate
+        )
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
-          filter(!(
-            (is.na(`10`) |
-              is.na(`20`) |
-              is.na(`30`) |
-              is.na(`40`) |
-              is.na(`60`) |
-              is.na(`70`) |
-              is.na(`90`) |
-              is.na(`98`)
-            ) &
-              target_end_date < dataCreationDate))
+          filter((
+              !is.na(`10`) &
+              !is.na(`20`) &
+              !is.na(`30`) &
+              !is.na(`40`) &
+              !is.na(`60`) &
+              !is.na(`70`) &
+              !is.na(`90`) &
+              !is.na(`98`)
+            ) |
+              target_end_date >= dataCreationDate
+          )
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)

--- a/app/server.R
+++ b/app/server.R
@@ -455,21 +455,25 @@ server <- function(input, output, session) {
     if (input$scoreType == "wis" || input$scoreType == "sharpness") {
       # Only show WIS or Sharpness for forecasts that have all intervals unless they are for future dates
       filteredScoreDf <- filteredScoreDf %>%
-        filter(!(is.na(`50`) &&
-          is.na(`80`) &&
-          is.na(`95`) &&
-          target_end_date < dataCreationDate))
+        filter(!(
+          (is.na(`50`) |
+            is.na(`80`) |
+            is.na(`95`)
+          ) &
+            target_end_date < dataCreationDate))
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
-          filter(!(is.na(`10`) &&
-            is.na(`20`) &&
-            is.na(`30`) &&
-            is.na(`40`) &&
-            is.na(`60`) &&
-            is.na(`70`) &&
-            is.na(`90`) &&
-            is.na(`98`) &&
-            target_end_date < dataCreationDate))
+          filter(!(
+            (is.na(`10`) |
+              is.na(`20`) |
+              is.na(`30`) |
+              is.na(`40`) |
+              is.na(`60`) |
+              is.na(`70`) |
+              is.na(`90`) |
+              is.na(`98`)
+            ) &
+              target_end_date < dataCreationDate))
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)

--- a/app/server.R
+++ b/app/server.R
@@ -317,6 +317,13 @@ server <- function(input, output, session) {
       theme_bw() +
       theme(panel.spacing = unit(0.5, "lines"))
 
+    if (input$showForecasts) {
+      maxLim <- max(
+        as.Date(input$asOf) + 7 * 4,
+        filteredScoreDf %>% filter(!is.na(Score)) %>% pull(Week_End_Date) %>% max() + 7 * 2
+      )
+      p <- p + scale_x_date(limits = c(as.Date(NA), maxLim), date_labels = "%b %Y")
+    }
     if (input$scoreType == "coverage") {
       p <- p + geom_hline(yintercept = .01 * as.integer(input$coverageInterval))
     }
@@ -390,9 +397,14 @@ server <- function(input, output, session) {
         geom_point(aes(y = Reported_Incidence))
     }
     if (input$showForecasts) {
+      maxLim <- max(
+        as.Date(input$asOf) + 7 * 4,
+        filteredDf %>% filter(!is.na(Reported_Incidence)) %>% pull(Week_End_Date) %>% max() + 7 * 2
+      )
       finalPlot <- finalPlot +
         geom_line(aes(y = Quantile_50, color = Forecaster)) +
-        geom_point(aes(y = Quantile_50, color = Forecaster, shape = Forecaster))
+        geom_point(aes(y = Quantile_50, color = Forecaster, shape = Forecaster)) +
+        scale_x_date(limits = c(as.Date(NA), maxLim), date_labels = "%b %Y")
     }
     finalPlot <- ggplotly(finalPlot, tooltip = c("shape", "x", "y")) %>%
       layout(

--- a/app/server.R
+++ b/app/server.R
@@ -320,9 +320,10 @@ server <- function(input, output, session) {
       theme(panel.spacing = unit(0.5, "lines"))
 
     if (input$showForecasts) {
-      maxLim <- max(
+      maxLim <- if_else(
+        as.Date(input$asOf) + 7 * 4 > CURRENT_WEEK_END_DATE(),
         as.Date(input$asOf) + 7 * 4,
-        CURRENT_WEEK_END_DATE() + 7 * 1
+        as.Date(NA)
       )
       p <- p + scale_x_date(limits = c(as.Date(NA), maxLim), date_labels = "%b %Y")
     }
@@ -399,9 +400,10 @@ server <- function(input, output, session) {
         geom_point(aes(y = Reported_Incidence))
     }
     if (input$showForecasts) {
-      maxLim <- max(
+      maxLim <- if_else(
+        as.Date(input$asOf) + 7 * 4 > CURRENT_WEEK_END_DATE(),
         as.Date(input$asOf) + 7 * 4,
-        CURRENT_WEEK_END_DATE() + 7 * 1
+        as.Date(NA)
       )
       finalPlot <- finalPlot +
         geom_line(aes(y = Quantile_50, color = Forecaster)) +

--- a/app/server.R
+++ b/app/server.R
@@ -417,7 +417,11 @@ server <- function(input, output, session) {
     # Remove the extra grouping from the legend: "(___,1)"
     for (i in seq_along(finalPlot$x$data)) {
       if (!is.null(finalPlot$x$data[[i]]$name)) {
+        if (endsWith(finalPlot$x$data[[i]]$name, ",1)") && finalPlot$x$data[[i]]$mode != "lines+markers") {
+          finalPlot$x$data[[i]]$showlegend <- FALSE
+        }
         finalPlot$x$data[[i]]$name <- gsub("\\(", "", stringr::str_split(finalPlot$x$data[[i]]$name, ",")[[1]][1])
+        finalPlot$x$data[[i]]$mode <- "lines+markers"
       }
     }
     return(finalPlot)

--- a/app/server.R
+++ b/app/server.R
@@ -322,7 +322,7 @@ server <- function(input, output, session) {
     if (input$showForecasts) {
       maxLim <- max(
         as.Date(input$asOf) + 7 * 4,
-        filteredScoreDf %>% filter(!is.na(Score)) %>% pull(Week_End_Date) %>% max() + 7 * 2
+        CURRENT_WEEK_END_DATE() + 7 * 1
       )
       p <- p + scale_x_date(limits = c(as.Date(NA), maxLim), date_labels = "%b %Y")
     }
@@ -401,7 +401,7 @@ server <- function(input, output, session) {
     if (input$showForecasts) {
       maxLim <- max(
         as.Date(input$asOf) + 7 * 4,
-        filteredDf %>% filter(!is.na(Reported_Incidence)) %>% pull(Week_End_Date) %>% max() + 7 * 2
+        CURRENT_WEEK_END_DATE() + 7 * 1
       )
       finalPlot <- finalPlot +
         geom_line(aes(y = Quantile_50, color = Forecaster)) +

--- a/app/server.R
+++ b/app/server.R
@@ -109,7 +109,9 @@ server <- function(input, output, session) {
 
 
   # Get scores
-  df <- loadData()
+  loaded <- loadData()
+  df <- loaded$df
+  dataCreationDate <- loaded$dataCreationDate
   DATA_LOADED <- TRUE
 
   # Prepare input choices
@@ -163,7 +165,7 @@ server <- function(input, output, session) {
 
     # Totaling over all locations
     if (SUMMARIZING_OVER_ALL_LOCATIONS()) {
-      filteredScoreDfAndIntersections <- filterOverAllLocations(filteredScoreDf, input$scoreType, !is.null(asOfData))
+      filteredScoreDfAndIntersections <- filterOverAllLocations(filteredScoreDf, input$scoreType, !is.null(asOfData), filterDate = dataCreationDate)
       filteredScoreDf <- filteredScoreDfAndIntersections[[1]]
       locationsIntersect <- filteredScoreDfAndIntersections[[2]]
       if (input$showForecasts) {
@@ -450,7 +452,7 @@ server <- function(input, output, session) {
         filter(!(is.na(`50`) &&
           is.na(`80`) &&
           is.na(`95`) &&
-          target_end_date < today()))
+          target_end_date < dataCreationDate))
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
           filter(!(is.na(`10`) &&
@@ -461,7 +463,7 @@ server <- function(input, output, session) {
             is.na(`70`) &&
             is.na(`90`) &&
             is.na(`98`) &&
-            target_end_date < today()))
+            target_end_date < dataCreationDate))
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)

--- a/app/server.R
+++ b/app/server.R
@@ -452,12 +452,12 @@ server <- function(input, output, session) {
     if (input$scoreType == "wis" || input$scoreType == "sharpness") {
       # Only show WIS or Sharpness for forecasts that have all intervals unless they are for future dates
       filteredScoreDf <- filteredScoreDf %>%
-        filter(!(
-          (is.na(`50`) |
-            is.na(`80`) |
-            is.na(`95`)
-          ) &
-            target_end_date < dataCreationDate))
+        filter((
+            !is.na(`50`) &
+            !is.na(`80`) &
+            !is.na(`95`)
+          ) |
+            target_end_date >= dataCreationDate)
       if (input$targetVariable == "Deaths") {
         filteredScoreDf <- filteredScoreDf %>%
           filter(!(

--- a/app/ui.R
+++ b/app/ui.R
@@ -98,12 +98,10 @@ sidebar <- tags$div(
     tags$p(id = "missing-data-disclaimer", "Some locations may not have 'as of' data for the chosen 'as of' date"),
     div(
       id = "showForecastsCheckbox",
-      disabled(
-        checkboxInput(
-          "showForecasts",
-          "Show Forecasters' Predictions",
-          value = FALSE,
-        )
+      checkboxInput(
+        "showForecasts",
+        "Show Forecasters' Predictions",
+        value = FALSE
       )
     ),
     tags$hr(),


### PR DESCRIPTION
### Description
Allow users to request and see predictions for future dates made by selected forecasters.

### Changes
- `Makefile`: `pull_data` target to pull [new saved datetime](https://github.com/cmu-delphi/forecast-eval/pull/228).
- `app/R/data.R`: data loader to get cached datetime in addition to scores.
- `app.ui.R`: enable "show forecasts" button for all as-of dates by default.
- `app/R/data_manipulation.R`: `filterOverAllLocations()` to take new `filterDate` arg. `filterDate` is used to remove predictions that are in the past (relative to when the data was generated) but don't have scores despite having truth data available. This lets us keep predictions that are in the future and don't have scores (because truth data wasn't available).
- `app/server.R`:
    - Get new cached datetime.
    - Explicitly set summary plot and truth plot x-axis ranges to be the same when predictions are shown on the truth plot. Since predictions are shown only on the truth plot and can appear in the future, axis auto-scaling can extend the max date past what is displayed in the summary plot and make it hard to compare between the plots.
    - Patch the truth plot legend parsing. The `plotly` package seems to have changed handling of `ggplot` legends so that we see duplicate entries for a given forecaster.
    - Change `filterScoreDf()` logic to match `filterOverAllLocations()
    - Generalize `filterForecastData()` to work with (past as-of dates) or without (most recent as-of date) as-of data.
    - Remove blocks to show or hide the "show forecasts" button, since we want to show it for all as-of dates now.

### Fixes
Closes #203