### PR TITLE
Set DESCRIPTION, .bumpversion.cfg, and app/global.R versions all to 4.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.2.0
 commit = False
 tag = False
 

--- a/app/global.R
+++ b/app/global.R
@@ -8,7 +8,7 @@ library(viridis)
 library(tsibble)
 library(covidcast)
 
-appVersion <- "4.0.0"
+appVersion <- "4.2.0"
 
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
 DEATH_FILTER <- "deaths_incidence_num"


### PR DESCRIPTION
### Description
Package version numbers diverged (4.0.0 in some places and 4.2.0 in some places). This caused the [release process to fail](https://github.com/cmu-delphi/forecast-eval/runs/5745230265?check_suite_focus=true#step:5:24) when the expected version number wasn't found in the DESCRIPTION file.