### PR TITLE
Download only recently added or changed forecaster files

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -45,6 +45,8 @@ jobs:
           password: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
           
       - name: Deploy score files to S3 bucket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make deploy
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ score_forecast: r_build dist pull_data
 		-v ${PWD}/Report:/var/forecast-eval \
 		-v ${PWD}/dist:/var/dist \
 		-w /var/forecast-eval \
+		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		forecast-eval-build \
 		Rscript create_reports.R --dir /var/dist
 


### PR DESCRIPTION
### Description
Instead of recreating `predictions_cards` from scratch every time the pipeline is run, download and process only files that have been added or modified since the last pipeline run. Added and modified files are selected based on commit history pulled from the [Reich Lab repository](https://github.com/reichlab/covid19-forecast-hub/tree/master/data-processed) via the GitHub REST API.

The new files are joined onto the predictions card object from the previous run, downloaded from the S3 bucket, and deduplicated in case any predictions were modified.

### Changes
- `Makefile`
- `s3_upload_ec2.yml` (self-hosted workflow)
- `Report/create_reports.R`