### PR TITLE
Increase fetch depth in `release-main` workflow so `main` and `dev` branches see the same commit history

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   correct_repository:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: dev
+          fetch-depth: 0
           ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
       - name: Reset dev branch
         run: |


### PR DESCRIPTION
Merging `main` into `dev` during the release process raises [an error](https://github.com/cmu-delphi/forecast-eval/runs/5858409354?check_suite_focus=true#step:3:21) indicating that git doesn't recognize the two branches as having shared commit history. Solution from https://github.com/actions/checkout/issues/125.

Allow workflow to be run manually in case automatic release fails.