### PR TITLE
Dashboard speed optimization by reducing redundant plot function calls

### DIFF
--- a/app/R/data.R
+++ b/app/R/data.R
@@ -84,16 +84,13 @@ getAllData <- function(loadFile) {
     covCols
   )
 
-  dfStateCases <- dfStateCases %>% select(all_of(expectedCols))
-  dfStateDeaths <- dfStateDeaths %>% select(all_of(expectedCols))
-  dfStateHospitalizations <- dfStateHospitalizations %>% select(all_of(expectedCols))
-  dfNationCases <- dfNationCases %>% select(all_of(expectedCols))
-  dfNationDeaths <- dfNationDeaths %>% select(all_of(expectedCols))
-  dfNationHospitalizations <- dfNationHospitalizations %>% select(all_of(expectedCols))
-
-  df <- rbind(
-    dfStateCases, dfStateDeaths, dfStateHospitalizations,
-    dfNationCases, dfNationDeaths, dfNationHospitalizations
+  df <- bind_rows(
+    dfStateCases %>% select(all_of(expectedCols)),
+    dfStateDeaths %>% select(all_of(expectedCols)),
+    dfStateHospitalizations %>% select(all_of(expectedCols)),
+    dfNationCases %>% select(all_of(expectedCols)),
+    dfNationDeaths %>% select(all_of(expectedCols)),
+    dfNationHospitalizations %>% select(all_of(expectedCols))
   )
   df <- df %>% rename(
     "10" = cov_10, "20" = cov_20, "30" = cov_30,

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -66,24 +66,29 @@ filterHospitalizationsAheads <- function(scoreDf) {
     group_by(target_end_date, forecaster) %>%
     filter(ahead == min(ahead)) %>%
     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1])
-  twoAheadDf <- scoreDf %>%
-    filter(ahead >= 7 + HOSPITALIZATIONS_OFFSET) %>%
-    filter(ahead < 14 + HOSPITALIZATIONS_OFFSET) %>%
-    group_by(target_end_date, forecaster) %>%
-    filter(ahead == min(ahead)) %>%
-    mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[2])
-  threeAheadDf <- scoreDf %>%
-    filter(ahead >= 14 + HOSPITALIZATIONS_OFFSET) %>%
-    filter(ahead < 21 + HOSPITALIZATIONS_OFFSET) %>%
-    group_by(target_end_date, forecaster) %>%
-    filter(ahead == min(ahead)) %>%
-    mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[3])
-  fourAheadDf <- scoreDf %>%
-    filter(ahead >= 21 + HOSPITALIZATIONS_OFFSET) %>%
-    filter(ahead < 28 + HOSPITALIZATIONS_OFFSET) %>%
-    group_by(target_end_date, forecaster) %>%
-    filter(ahead == min(ahead)) %>%
-    mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[4])
-
-  return(rbind(oneAheadDf, twoAheadDf, threeAheadDf, fourAheadDf))
+  
+  return(bind_rows(scoreDf %>%
+                     filter(ahead >= HOSPITALIZATIONS_OFFSET) %>%
+                     filter(ahead < 7 + HOSPITALIZATIONS_OFFSET) %>%
+                     group_by(target_end_date, forecaster) %>%
+                     filter(ahead == min(ahead)) %>%
+                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1]),
+                   scoreDf %>%
+                     filter(ahead >= 7 + HOSPITALIZATIONS_OFFSET) %>%
+                     filter(ahead < 14 + HOSPITALIZATIONS_OFFSET) %>%
+                     group_by(target_end_date, forecaster) %>%
+                     filter(ahead == min(ahead)) %>%
+                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[2]),
+                   scoreDf %>%
+                     filter(ahead >= 14 + HOSPITALIZATIONS_OFFSET) %>%
+                     filter(ahead < 21 + HOSPITALIZATIONS_OFFSET) %>%
+                     group_by(target_end_date, forecaster) %>%
+                     filter(ahead == min(ahead)) %>%
+                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[3]),
+                   scoreDf %>%
+                     filter(ahead >= 21 + HOSPITALIZATIONS_OFFSET) %>%
+                     filter(ahead < 28 + HOSPITALIZATIONS_OFFSET) %>%
+                     group_by(target_end_date, forecaster) %>%
+                     filter(ahead == min(ahead)) %>%
+                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[4])))
 }

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -66,29 +66,31 @@ filterHospitalizationsAheads <- function(scoreDf) {
     group_by(target_end_date, forecaster) %>%
     filter(ahead == min(ahead)) %>%
     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1])
-  
-  return(bind_rows(scoreDf %>%
-                     filter(ahead >= HOSPITALIZATIONS_OFFSET) %>%
-                     filter(ahead < 7 + HOSPITALIZATIONS_OFFSET) %>%
-                     group_by(target_end_date, forecaster) %>%
-                     filter(ahead == min(ahead)) %>%
-                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1]),
-                   scoreDf %>%
-                     filter(ahead >= 7 + HOSPITALIZATIONS_OFFSET) %>%
-                     filter(ahead < 14 + HOSPITALIZATIONS_OFFSET) %>%
-                     group_by(target_end_date, forecaster) %>%
-                     filter(ahead == min(ahead)) %>%
-                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[2]),
-                   scoreDf %>%
-                     filter(ahead >= 14 + HOSPITALIZATIONS_OFFSET) %>%
-                     filter(ahead < 21 + HOSPITALIZATIONS_OFFSET) %>%
-                     group_by(target_end_date, forecaster) %>%
-                     filter(ahead == min(ahead)) %>%
-                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[3]),
-                   scoreDf %>%
-                     filter(ahead >= 21 + HOSPITALIZATIONS_OFFSET) %>%
-                     filter(ahead < 28 + HOSPITALIZATIONS_OFFSET) %>%
-                     group_by(target_end_date, forecaster) %>%
-                     filter(ahead == min(ahead)) %>%
-                     mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[4])))
+
+  return(bind_rows(
+    scoreDf %>%
+      filter(ahead >= HOSPITALIZATIONS_OFFSET) %>%
+      filter(ahead < 7 + HOSPITALIZATIONS_OFFSET) %>%
+      group_by(target_end_date, forecaster) %>%
+      filter(ahead == min(ahead)) %>%
+      mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1]),
+    scoreDf %>%
+      filter(ahead >= 7 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(ahead < 14 + HOSPITALIZATIONS_OFFSET) %>%
+      group_by(target_end_date, forecaster) %>%
+      filter(ahead == min(ahead)) %>%
+      mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[2]),
+    scoreDf %>%
+      filter(ahead >= 14 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(ahead < 21 + HOSPITALIZATIONS_OFFSET) %>%
+      group_by(target_end_date, forecaster) %>%
+      filter(ahead == min(ahead)) %>%
+      mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[3]),
+    scoreDf %>%
+      filter(ahead >= 21 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(ahead < 28 + HOSPITALIZATIONS_OFFSET) %>%
+      group_by(target_end_date, forecaster) %>%
+      filter(ahead == min(ahead)) %>%
+      mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[4])
+  ))
 }

--- a/app/global.R
+++ b/app/global.R
@@ -7,12 +7,8 @@ library(lubridate)
 library(viridis)
 library(tsibble)
 library(covidcast)
-library(reactlog)
 
-#For debugging reasons you may want to use this function
-#reactlog_enable()
-
-appVersion <- "5.0.0"
+appVersion <- "5.1.0"
 
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
 DEATH_FILTER <- "deaths_incidence_num"

--- a/app/global.R
+++ b/app/global.R
@@ -29,9 +29,6 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
-# Current Aheads
-CURRENT_AHEAD_OPTION <- AHEAD_OPTIONS
-
 # Sets the previous target to be the same as the first one, Deaths
 PREV_TARGET <- "Deaths"
 

--- a/app/global.R
+++ b/app/global.R
@@ -29,6 +29,12 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
+# Current Aheads
+CURRENT_AHEAD_OPTION <- AHEAD_OPTIONS
+
+# Sets the previous target to be the same as the first one, Deaths
+PREV_TARGET <- "Deaths"
+
 # Earliest 'as of' date available from covidcast API
 MIN_AVAIL_NATION_AS_OF_DATE <- as.Date("2020-04-02")
 MIN_AVAIL_HOSP_AS_OF_DATE <- as.Date("2020-11-16")

--- a/app/global.R
+++ b/app/global.R
@@ -36,7 +36,11 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
 # Sets the previous target to be the same as the first one, Deaths
 PREV_TARGET <- "Deaths"
 
-# Sets 
+# When RE_RENDER_TRUTH = TRUE
+# summaryPlot will be called only to update TruthPlot
+RE_RENDER_TRUTH <- FALSE
+
+# RENDER_TRUTH indicates when it is not necessary to call truthPlot again
 RENDER_TRUTH <- TRUE
 
 # Earliest 'as of' date available from covidcast API

--- a/app/global.R
+++ b/app/global.R
@@ -7,6 +7,10 @@ library(lubridate)
 library(viridis)
 library(tsibble)
 library(covidcast)
+library(reactlog)
+
+#For debugging reasons you may want to use this function
+#reactlog_enable()
 
 appVersion <- "5.0.0"
 

--- a/app/global.R
+++ b/app/global.R
@@ -36,8 +36,8 @@ PREV_TARGET <- "Deaths"
 # summaryPlot will be called only to update TruthPlot
 RE_RENDER_TRUTH <- FALSE
 
-# USE_CURR_TRUTH indicates when we can use the previous TruthPlot 
-USE_CURR_TRUTH <- FALSE 
+# USE_CURR_TRUTH indicates when we can use the previous TruthPlot
+USE_CURR_TRUTH <- FALSE
 
 # Earliest 'as of' date available from covidcast API
 MIN_AVAIL_NATION_AS_OF_DATE <- as.Date("2020-04-02")

--- a/app/global.R
+++ b/app/global.R
@@ -32,6 +32,9 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
 # Sets the previous target to be the same as the first one, Deaths
 PREV_TARGET <- "Deaths"
 
+# Sets 
+RENDER_TRUTH <- TRUE
+
 # Earliest 'as of' date available from covidcast API
 MIN_AVAIL_NATION_AS_OF_DATE <- as.Date("2020-04-02")
 MIN_AVAIL_HOSP_AS_OF_DATE <- as.Date("2020-11-16")

--- a/app/global.R
+++ b/app/global.R
@@ -36,8 +36,8 @@ PREV_TARGET <- "Deaths"
 # summaryPlot will be called only to update TruthPlot
 RE_RENDER_TRUTH <- FALSE
 
-# RENDER_TRUTH indicates when it is not necessary to call truthPlot again
-RENDER_TRUTH <- TRUE
+# USE_CURR_TRUTH indicates when we can use the previous TruthPlot 
+USE_CURR_TRUTH <- FALSE 
 
 # Earliest 'as of' date available from covidcast API
 MIN_AVAIL_NATION_AS_OF_DATE <- as.Date("2020-04-02")

--- a/app/server.R
+++ b/app/server.R
@@ -655,10 +655,12 @@ server <- function(input, output, session) {
   # When the target variable changes, update available forecasters, locations, and CIs to choose from
   observeEvent(input$targetVariable, {
 
-    # removing previous asofData
+    ## summaryPlot will try to use PREV_AS_OF_DATA()
+    ## since it has wrong data information, it needs to be removed
     PREV_AS_OF_DATA(NULL)
-    ## Defining Filter
     if (input$targetVariable == "Deaths") {
+    
+    ## Defining Filter
       FILTER <- DEATH_FILTER
     } else if (input$targetVariable == "Cases") {
       FILTER <- CASE_FILTER

--- a/app/server.R
+++ b/app/server.R
@@ -659,8 +659,8 @@ server <- function(input, output, session) {
     ## since it has wrong data information, it needs to be removed
     PREV_AS_OF_DATA(NULL)
     if (input$targetVariable == "Deaths") {
-    
-    ## Defining Filter
+
+      ## Defining Filter
       FILTER <- DEATH_FILTER
     } else if (input$targetVariable == "Cases") {
       FILTER <- CASE_FILTER

--- a/app/server.R
+++ b/app/server.R
@@ -35,7 +35,6 @@ updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices
 
 updateLocationChoices <- function(session, df, targetVariable, forecasterChoices, locationInput) {
   df <- df %>% filter(forecaster %in% forecasterChoices)
-  # locationChoices <- unique(toupper(df$geo_value))
   locationChoices <- distinct(df, geo_value) %>%
     pull() %>%
     toupper()
@@ -116,7 +115,7 @@ server <- function(input, output, session) {
 
   # Prepare input choices
   # forecasterChoices <- sort(unique(df$forecaster))
-  forecasterChoices <- distinct(df, forecaster) %>% pull()
+  forecasterChoices <- distinct(df, forecaster) %>% pull() %>% sort()
 
   updateForecasterChoices(session, df, forecasterChoices, "wis")
 
@@ -271,7 +270,7 @@ server <- function(input, output, session) {
         TRUTH_PLOT
       })
     } else {
-      if (!RENDER_TRUTH && input$showForecasts == FALSE) {
+      if (USE_CURR_TRUTH && input$showForecasts == FALSE) {
         output$truthPlot <- renderPlotly({
           TRUTH_PLOT
         })
@@ -282,7 +281,7 @@ server <- function(input, output, session) {
         })
       }
     }
-    RENDER_TRUTH <<- TRUE
+    USE_CURR_TRUTH <<- TRUE
     # If we are just re-rendering the truth plot with as of data
     # we don't need to re-render the score plot
     if (RE_RENDER_TRUTH) {
@@ -644,7 +643,7 @@ server <- function(input, output, session) {
   observeEvent(input$refreshColors,
     {
       COLOR_SEED(floor(runif(1, 1, 1000)))
-      RENDER_TRUTH <<- FALSE
+      USE_CURR_TRUTH <<- TRUE
     },
     ignoreInit = TRUE
   )
@@ -739,7 +738,7 @@ server <- function(input, output, session) {
         hideElement("aeExplanation")
         showElement("coverageExplanation")
       }
-      RENDER_TRUTH <<- FALSE
+      USE_CURR_TRUTH <<- TRUE
     },
     ignoreInit = TRUE
   )
@@ -758,15 +757,15 @@ server <- function(input, output, session) {
     updateAheadChoices(session, df, input$targetVariable, input$forecasters, input$aheads, FALSE)
     updateLocationChoices(session, df, input$targetVariable, input$forecasters, input$location)
     updateCoverageChoices(session, df, input$targetVariable, input$forecasters, input$coverageInterval, output)
-    RENDER_TRUTH <<- FALSE
+    USE_CURR_TRUTH <<- TRUE
   })
 
   observeEvent(input$scaleByBaseline, {
-    RENDER_TRUTH <<- FALSE
+    USE_CURR_TRUTH <<- TRUE
   })
 
   observeEvent(input$logScale, {
-    RENDER_TRUTH <<- FALSE
+    USE_CURR_TRUTH <<- TRUE
   })
 
   observeEvent(input$location,

--- a/app/server.R
+++ b/app/server.R
@@ -74,7 +74,6 @@ updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, a
     hideElement("horizon-disclaimer")
   }
   aheadChoices <- Filter(function(x) any(unique(df$ahead) %in% x), aheadOptions)
-  CURRENT_AHEAD_OPTION <<- aheadOptions
   # Ensure previsouly selected options are still allowed
   if (!is.null(aheads) && aheads %in% aheadChoices) {
     selectedAheads <- aheads
@@ -86,10 +85,10 @@ updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, a
     selectedAheads <- aheadOptions[1]
   }
   updateCheckboxGroupInput(session, "aheads",
-    title,
-    choices = aheadChoices,
-    selected = selectedAheads,
-    inline = TRUE
+                           title,
+                           choices = aheadChoices,
+                           selected = selectedAheads,
+                           inline = TRUE
   )
 }
 # All data is fully loaded from AWS
@@ -126,8 +125,7 @@ server <- function(input, output, session) {
   # CREATE MAIN PLOT
   ##################
   summaryPlot <- function(reRenderTruth = FALSE, asOfData = NULL, renderTruth = TRUE) {
-    
-    #browser()
+    browser()
     ###checking if aheads options matches with the target variable:
     ###if not, return()
     ### if(input$targetVariable%in%c("Deaths","Cases") &&
@@ -797,7 +795,7 @@ server <- function(input, output, session) {
   })
 
   updateAsOfData <- function(fetchDate = input$asOf) {
-    #browser()
+    browser()
     if (as.character(fetchDate) == "") {
       return()
     }

--- a/app/server.R
+++ b/app/server.R
@@ -122,7 +122,6 @@ server <- function(input, output, session) {
   # CREATE MAIN PLOT
   ##################
   summaryPlot <- function() {
-    browser()
     if(input$location==''){
       return()
     }
@@ -808,7 +807,6 @@ server <- function(input, output, session) {
   })
 
   updateAsOfData <- function(fetchDate = input$asOf) {
-    browser()
     if (as.character(fetchDate) == "") {
       return()
     }


### PR DESCRIPTION
Because of how reactivity in shiny works,  there were many redundant calls. 

Every time that we update a reactive variable, it automatically triggers functions that depends on this reactive variable. For example: changing `input$targetVariable` triggers `summaryPlot`, so there is no need 

In this PR we removed some of those forced calls of functions that would already be triggered by reactivity.

For example, when changing colours, there is no need to call `summaryPlot` since it will alread be triggered by the change of the reactive variable `COLOR_SEED()`

Here is an example of change that was made:

From:

```
  observeEvent(input$refreshColors, {
    COLOR_SEED(floor(runif(1, 1, 1000)))
    output$summaryPlot <- renderPlotly({
      summaryPlot()
    })
  })
```

to:

```
  observeEvent(input$refreshColors,
    {
      COLOR_SEED(floor(runif(1, 1, 1000)))
      USE_CURR_TRUTH <<- TRUE
    },
    ignoreInit = TRUE
  )
```

