### PR TITLE
Remove Docker remnants in workflow to free memory

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -50,7 +50,10 @@ jobs:
 
       - name: Cleanup
         if: ${{ always() }}
-        run: docker ps -q | xargs -n 1 -P 8 -I {} docker stop {}
+        run: |
+          docker image prune -a -f
+          docker container prune -f
+          docker ps -q | xargs -n 1 -P 8 -I {} docker stop {}
         
         
         

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ S3_BUCKET=s3://forecast-eval
 build: build_dashboard
 
 r_build:
-	docker build --no-cache --pull -t forecast-eval-build docker_build
+	docker build --no-cache --force-rm --pull -t forecast-eval-build docker_build
 
 %.rds: dist
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@


### PR DESCRIPTION
Delete intermediate containers during build process, and delete other images and containers on workflow cleanup.

A buildup of old containers/images occasionally uses enough memory that the pipeline run fails and Docker remnants need to be delete manually. Do this automatically.