### PR TITLE
Use `evalcast` caching mechanism to reduce time to pull from API

### DIFF
--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -147,18 +147,24 @@ geo_type <- "state"
 offline_signal_dir <- "signal_cache"
 start_ts <- Sys.time()
 # Take advantage of `evalcast`'s caching feature. Since data used for scoring is
-# fetched one day or week at a time, it would create a cache covering a very 
+# fetched one day or week at a time, it would create a cache covering a very
 # narrow date range. Explicitly pull the full date range for each signal used.
-download_signal(data_source="hhs", signal="confirmed_admissions_covid_1d",
-                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
-download_signal(data_source="jhu-csse", signal="confirmed_incidence_num",
-                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
-download_signal(data_source="jhu-csse", signal="deaths_incidence_num",
-                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
+download_signal(
+  data_source = "hhs", signal = "confirmed_admissions_covid_1d",
+  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+)
+download_signal(
+  data_source = "jhu-csse", signal = "confirmed_incidence_num",
+  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+)
+download_signal(
+  data_source = "jhu-csse", signal = "deaths_incidence_num",
+  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+)
 state_scores <- evaluate_covid_predictions(state_predictions,
-                                           err_measures,
-                                           geo_type = geo_type,
-                                           offline_signal_dir = offline_signal_dir
+  err_measures,
+  geo_type = geo_type,
+  offline_signal_dir = offline_signal_dir
 )
 print(Sys.time() - start_ts)
 

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -144,10 +144,23 @@ save_score_errors <- list()
 ## Score predictions
 print("Evaluating state forecasts")
 geo_type <- "state"
+offline_signal_dir <- "signal_cache"
+start_ts <- Sys.time()
+# Take advantage of `evalcast`'s caching feature. Since data used for scoring is
+# fetched one day or week at a time, it would create a cache covering a very 
+# narrow date range. Explicitly pull the full date range for each signal used.
+download_signal(data_source="hhs", signal="confirmed_admissions_covid_1d",
+                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
+download_signal(data_source="jhu-csse", signal="confirmed_incidence_num",
+                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
+download_signal(data_source="jhu-csse", signal="deaths_incidence_num",
+                geo_type="state", geo_values="*", offline_signal_dir = offline_signal_dir)
 state_scores <- evaluate_covid_predictions(state_predictions,
-  err_measures,
-  geo_type = geo_type
+                                           err_measures,
+                                           geo_type = geo_type,
+                                           offline_signal_dir = offline_signal_dir
 )
+print(Sys.time() - start_ts)
 
 for (signal_name in signals) {
   status <- save_score_cards_wrapper(state_scores, geo_type, signal_name, output_dir)

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -159,20 +159,22 @@ offline_signal_dir <- "signal_cache"
 #
 # Circumvent this by explicitly pulling the full date range and initializing a
 # complete cache for each signal used.
+sources <- list(
+  list(data_source = "hhs", signal = "confirmed_admissions_covid_1d"),
+  list(data_source = "jhu-csse", signal = "confirmed_incidence_num"),
+  list(data_source = "jhu-csse", signal = "deaths_incidence_num")
+)
 invisible({
-  download_signal(
-    data_source = "hhs", signal = "confirmed_admissions_covid_1d",
-    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-  )
-  download_signal(
-    data_source = "jhu-csse", signal = "confirmed_incidence_num",
-    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-  )
-  download_signal(
-    data_source = "jhu-csse", signal = "deaths_incidence_num",
-    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-  )
+  for (source in sources) {
+    download_signal(
+      data_source = source$data_source, signal = source$signal,
+      # "us" can also be included in `states_geos`. Drop to avoid "Data not
+      # fetched for some geographies" error.
+      geo_type = "state", geo_values = setdiff(state_geos, "us"), offline_signal_dir = offline_signal_dir
+    )
+  }
 })
+
 state_scores <- evaluate_covid_predictions(state_predictions,
   err_measures,
   geo_type = geo_type,

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -149,18 +149,21 @@ start_ts <- Sys.time()
 # Take advantage of `evalcast`'s caching feature. Since data used for scoring is
 # fetched one day or week at a time, it would create a cache covering a very
 # narrow date range. Explicitly pull the full date range for each signal used.
-download_signal(
-  data_source = "hhs", signal = "confirmed_admissions_covid_1d",
-  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-)
-download_signal(
-  data_source = "jhu-csse", signal = "confirmed_incidence_num",
-  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-)
-download_signal(
-  data_source = "jhu-csse", signal = "deaths_incidence_num",
-  geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
-)
+# Suppress output since we only care about generating the cache.
+invisible({
+  download_signal(
+    data_source = "hhs", signal = "confirmed_admissions_covid_1d",
+    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+  )
+  download_signal(
+    data_source = "jhu-csse", signal = "confirmed_incidence_num",
+    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+  )
+  download_signal(
+    data_source = "jhu-csse", signal = "deaths_incidence_num",
+    geo_type = "state", geo_values = "*", offline_signal_dir = offline_signal_dir
+  )
+})
 state_scores <- evaluate_covid_predictions(state_predictions,
   err_measures,
   geo_type = geo_type,

--- a/app/server.R
+++ b/app/server.R
@@ -654,12 +654,10 @@ server <- function(input, output, session) {
 
   # When the target variable changes, update available forecasters, locations, and CIs to choose from
   observeEvent(input$targetVariable, {
-
     ## summaryPlot will try to use PREV_AS_OF_DATA()
     ## since it has wrong data information, it needs to be removed
     PREV_AS_OF_DATA(NULL)
     if (input$targetVariable == "Deaths") {
-
       ## Defining Filter
       FILTER <- DEATH_FILTER
     } else if (input$targetVariable == "Cases") {


### PR DESCRIPTION
`evalcast` pulls each day/week of truth data from the COVIDcast API one by one. Since the overhead dominates the pull time, this is slow compared to pulling all desired dates at once. We can do this using the caching feature in `evalcast`.

This reduces the time to pull data from 3h 20m to 20m. Max memory usage decreases ~7 GB.