### PR TITLE
Display archived signals in separate tab on dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,6 @@ PWD=$(shell pwd)
 S3_URL=https://forecast-eval.s3.us-east-2.amazonaws.com
 S3_BUCKET=s3://forecast-eval
 
-# Change dashboard type during `make` call via `make <command> DASH_TYPE="<type>"`
-#
-# DASH_TYPE can be set to "current" (for hosp forecasts) or "archive" (for death
-# and cases forecasts).
-DASH_TYPE="current"
-
 build: build_dashboard
 
 r_build:
@@ -58,7 +52,4 @@ deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
-	docker run --rm \
-		-p 3838:80 \
-		--env DASH_TYPE=$(DASH_TYPE) \
-		ghcr.io/cmu-delphi/forecast-eval:latest
+	docker run --rm -p 3838:80 ghcr.io/cmu-delphi/forecast-eval:latest

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ r_build:
 %.rds: dist
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@
 
-pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds
+pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds predictions_cards.rds
 
 dist:
 	mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 S3_URL=https://forecast-eval.s3.us-east-2.amazonaws.com
 S3_BUCKET=s3://forecast-eval
 
+# Change dashboard type during `make` call via `make <command> DASH_TYPE="<type>"`
+#
+# DASH_TYPE can be set to "current" (for hosp forecasts) or "archive" (for death
+# and cases forecasts).
+DASH_TYPE="current"
+
 build: build_dashboard
 
 r_build:
@@ -36,6 +42,7 @@ start_dev: r_build
 		-v ${PWD}/app:/var/forecast-eval-dashboard \
 		-v ${PWD}/dist:/var/dist \
 		-w /var/forecast-eval \
+		--env DASH_TYPE=$(DASH_TYPE) \
 		ghcr.io/cmu-delphi/forecast-eval:latest bash
 
 build_dashboard_dev: pull_data
@@ -48,5 +55,7 @@ deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
-	#--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE)
-	docker run --rm -p 3838:80 ghcr.io/cmu-delphi/forecast-eval:latest
+	docker run --rm \
+		-p 3838:80 \
+		--env DASH_TYPE=$(DASH_TYPE) \
+		ghcr.io/cmu-delphi/forecast-eval:latest

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ start_dev: r_build
 		-v ${PWD}/app:/var/forecast-eval-dashboard \
 		-v ${PWD}/dist:/var/dist \
 		-w /var/forecast-eval \
-		--env DASH_TYPE=$(DASH_TYPE) \
 		ghcr.io/cmu-delphi/forecast-eval:latest bash
 
 build_dashboard_dev: pull_data

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,5 @@ deploy_dashboard: build_dashboard
 	docker push ghcr.io/cmu-delphi/forecast-eval:$(imageTag)
 
 start_dashboard: build_dashboard_dev
+	#--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE)
 	docker run --rm -p 3838:80 ghcr.io/cmu-delphi/forecast-eval:latest

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL:=/bin/bash
+PWD=$(shell pwd)
+
 .DEFAULT_GOAL:=build
 S3_URL=https://forecast-eval.s3.us-east-2.amazonaws.com
 S3_BUCKET=s3://forecast-eval

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -5,7 +5,7 @@ library(aws.s3)
 shinyOptions(cache = cachem::cache_mem(max_size = 1000 * 1024^2, evict = "lru"))
 cache <- getShinyOption("cache")
 
-# Since covidcast data updates about once a day. Add date arg to
+# Since covidcast data updates about once a day, add date arg to
 # covidcast_signal so caches aren't used after that.
 covidcast_signal_mem <- function(..., date = Sys.Date()) {
   return(covidcast_signal(...))
@@ -84,14 +84,19 @@ getAllData <- function(loadFile) {
     covCols
   )
 
-  df <- bind_rows(
-    dfStateCases %>% select(all_of(expectedCols)),
-    dfStateDeaths %>% select(all_of(expectedCols)),
-    dfStateHospitalizations %>% select(all_of(expectedCols)),
-    dfNationCases %>% select(all_of(expectedCols)),
-    dfNationDeaths %>% select(all_of(expectedCols)),
-    dfNationHospitalizations %>% select(all_of(expectedCols))
+  df <- dash_type_toggle(
+    curr_val = bind_rows(
+      dfStateHospitalizations %>% select(all_of(expectedCols)),
+      dfNationHospitalizations %>% select(all_of(expectedCols))
+    ),
+    arch_val = bind_rows(
+      dfStateCases %>% select(all_of(expectedCols)),
+      dfStateDeaths %>% select(all_of(expectedCols)),
+      dfNationCases %>% select(all_of(expectedCols)),
+      dfNationDeaths %>% select(all_of(expectedCols))
+    )
   )
+  
   df <- df %>% rename(
     "10" = cov_10, "20" = cov_20, "30" = cov_30,
     "40" = cov_40, "50" = cov_50, "60" = cov_60, "70" = cov_70,

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -82,20 +82,17 @@ getAllData <- function(loadFile) {
     dfNationCases,
     dfNationDeaths
   )
-
-  # Pick out expected columns only
-  expectedCols <- c(
+  
+  # The names of the `covCols` elements become the new names of those columns
+  # when we use this vector in the `select` below.
+  covCols <- setNames(paste0("cov_", COVERAGE_INTERVALS), COVERAGE_INTERVALS)
+  keepCols <- c(
     "ahead", "geo_value", "forecaster", "forecast_date",
     "data_source", "signal", "target_end_date", "incidence_period",
-    "actual", "wis", "sharpness", "ae", "value_50"
+    "actual", "wis", "sharpness", "ae", "value_50",
+    covCols
   )
-  df <- select(
-    df,
-    all_of(expectedCols),
-    "10" = cov_10, "20" = cov_20, "30" = cov_30,
-    "40" = cov_40, "50" = cov_50, "60" = cov_60, "70" = cov_70,
-    "80" = cov_80, "90" = cov_90, "95" = cov_95, "98" = cov_98
-  )
+  df <- select(df, all_of(keepCols))
 
   return(df)
 }

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -75,14 +75,14 @@ getAllData <- function(loadFile) {
   dfNationCases <- loadFile("score_cards_nation_cases.rds")
   dfNationDeaths <- loadFile("score_cards_nation_deaths.rds")
   df <- bind_rows(
-      dfStateHospitalizations,
-      dfNationHospitalizations,
-      dfStateCases,
-      dfStateDeaths,
-      dfNationCases,
-      dfNationDeaths
-    )
-  
+    dfStateHospitalizations,
+    dfNationHospitalizations,
+    dfStateCases,
+    dfStateDeaths,
+    dfNationCases,
+    dfNationDeaths
+  )
+
   # Pick out expected columns only
   expectedCols <- c(
     "ahead", "geo_value", "forecaster", "forecast_date",

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -82,7 +82,7 @@ getAllData <- function(loadFile) {
     dfNationCases,
     dfNationDeaths
   )
-  
+
   # The names of the `covCols` elements become the new names of those columns
   # when we use this vector in the `select` below.
   covCols <- setNames(paste0("cov_", COVERAGE_INTERVALS), COVERAGE_INTERVALS)

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -68,41 +68,44 @@ getCreationDate <- function(loadFile) {
 
 
 getAllData <- function(loadFile) {
-  dfStateCases <- loadFile("score_cards_state_cases.rds")
-  dfStateDeaths <- loadFile("score_cards_state_deaths.rds")
-  dfStateHospitalizations <- loadFile("score_cards_state_hospitalizations.rds")
-  dfNationCases <- loadFile("score_cards_nation_cases.rds")
-  dfNationDeaths <- loadFile("score_cards_nation_deaths.rds")
-  dfNationHospitalizations <- loadFile("score_cards_nation_hospitalizations.rds")
-
+  df <- dash_type_toggle(
+    curr_val = {
+      dfStateHospitalizations <- loadFile("score_cards_state_hospitalizations.rds")
+      dfNationHospitalizations <- loadFile("score_cards_nation_hospitalizations.rds")
+      
+      bind_rows(
+        dfStateHospitalizations,
+        dfNationHospitalizations
+      )
+      
+    },
+    arch_val = {
+      dfStateCases <- loadFile("score_cards_state_cases.rds")
+      dfStateDeaths <- loadFile("score_cards_state_deaths.rds")
+      dfNationCases <- loadFile("score_cards_nation_cases.rds")
+      dfNationDeaths <- loadFile("score_cards_nation_deaths.rds")
+      
+      bind_rows(
+        dfStateCases,
+        dfStateDeaths,
+        dfNationCases,
+        dfNationDeaths
+      )
+    })
+  
   # Pick out expected columns only
-  covCols <- paste0("cov_", COVERAGE_INTERVALS)
   expectedCols <- c(
     "ahead", "geo_value", "forecaster", "forecast_date",
     "data_source", "signal", "target_end_date", "incidence_period",
-    "actual", "wis", "sharpness", "ae", "value_50",
-    covCols
+    "actual", "wis", "sharpness", "ae", "value_50"
   )
-
-  df <- dash_type_toggle(
-    curr_val = bind_rows(
-      dfStateHospitalizations %>% select(all_of(expectedCols)),
-      dfNationHospitalizations %>% select(all_of(expectedCols))
-    ),
-    arch_val = bind_rows(
-      dfStateCases %>% select(all_of(expectedCols)),
-      dfStateDeaths %>% select(all_of(expectedCols)),
-      dfNationCases %>% select(all_of(expectedCols)),
-      dfNationDeaths %>% select(all_of(expectedCols))
-    )
-  )
-  
-  df <- df %>% rename(
+  df <- select(
+    df,
+    all_of(expectedCols),
     "10" = cov_10, "20" = cov_20, "30" = cov_30,
     "40" = cov_40, "50" = cov_50, "60" = cov_60, "70" = cov_70,
     "80" = cov_80, "90" = cov_90, "95" = cov_95, "98" = cov_98
   )
-
   return(df)
 }
 

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -68,30 +68,20 @@ getCreationDate <- function(loadFile) {
 
 
 getAllData <- function(loadFile) {
-  df <- dash_type_toggle(
-    curr_val = {
-      dfStateHospitalizations <- loadFile("score_cards_state_hospitalizations.rds")
-      dfNationHospitalizations <- loadFile("score_cards_nation_hospitalizations.rds")
-      
-      bind_rows(
-        dfStateHospitalizations,
-        dfNationHospitalizations
-      )
-      
-    },
-    arch_val = {
-      dfStateCases <- loadFile("score_cards_state_cases.rds")
-      dfStateDeaths <- loadFile("score_cards_state_deaths.rds")
-      dfNationCases <- loadFile("score_cards_nation_cases.rds")
-      dfNationDeaths <- loadFile("score_cards_nation_deaths.rds")
-      
-      bind_rows(
-        dfStateCases,
-        dfStateDeaths,
-        dfNationCases,
-        dfNationDeaths
-      )
-    })
+  dfStateHospitalizations <- loadFile("score_cards_state_hospitalizations.rds")
+  dfNationHospitalizations <- loadFile("score_cards_nation_hospitalizations.rds")
+  dfStateCases <- loadFile("score_cards_state_cases.rds")
+  dfStateDeaths <- loadFile("score_cards_state_deaths.rds")
+  dfNationCases <- loadFile("score_cards_nation_cases.rds")
+  dfNationDeaths <- loadFile("score_cards_nation_deaths.rds")
+  df <- bind_rows(
+      dfStateHospitalizations,
+      dfNationHospitalizations,
+      dfStateCases,
+      dfStateDeaths,
+      dfNationCases,
+      dfNationDeaths
+    )
   
   # Pick out expected columns only
   expectedCols <- c(
@@ -106,6 +96,7 @@ getAllData <- function(loadFile) {
     "40" = cov_40, "50" = cov_50, "60" = cov_60, "70" = cov_70,
     "80" = cov_80, "90" = cov_90, "95" = cov_95, "98" = cov_98
   )
+
   return(df)
 }
 

--- a/app/global.R
+++ b/app/global.R
@@ -10,7 +10,6 @@ library(covidcast)
 
 appVersion <- "6.0.0"
 
-
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
 DEATH_FILTER <- "deaths_incidence_num"
 CASE_FILTER <- "confirmed_incidence_num"

--- a/app/global.R
+++ b/app/global.R
@@ -10,6 +10,8 @@ library(covidcast)
 
 appVersion <- "6.0.0"
 
+DASH_TYPE <- match.arg(Sys.getenv("DASH_TYPE"), c("current", "archive"))
+
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
 DEATH_FILTER <- "deaths_incidence_num"
 CASE_FILTER <- "confirmed_incidence_num"
@@ -73,4 +75,11 @@ resolveCurrentHospDay <- function() {
   # the most recent Saturday / Wednesday date even though the actual updated data won't be there yet)
   prevHospWeek <- seq(Sys.Date() - 10, Sys.Date() - 4, by = "day")
   prevHospWeek[weekdays(prevHospWeek) == HOSPITALIZATIONS_TARGET_DAY]
+}
+
+dash_type_toggle <- function(curr_val, arch_val) {
+  switch(DASH_TYPE,
+         current = curr_val,
+         archive = arch_val
+  )
 }

--- a/app/global.R
+++ b/app/global.R
@@ -29,8 +29,8 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
-# Sets the previous target to be the same as the first one, Deaths
-PREV_TARGET <- "Deaths"
+# Sets the "previous" target to be the same as the first one
+PREV_TARGET <- "Hospitalizations"
 
 # When RE_RENDER_TRUTH = TRUE
 # summaryPlot will be called only to update TruthPlot

--- a/app/global.R
+++ b/app/global.R
@@ -10,7 +10,6 @@ library(covidcast)
 
 appVersion <- "6.0.0"
 
-DASH_TYPE <- match.arg(Sys.getenv("DASH_TYPE"), c("current", "archive"))
 
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
 DEATH_FILTER <- "deaths_incidence_num"
@@ -75,11 +74,4 @@ resolveCurrentHospDay <- function() {
   # the most recent Saturday / Wednesday date even though the actual updated data won't be there yet)
   prevHospWeek <- seq(Sys.Date() - 10, Sys.Date() - 4, by = "day")
   prevHospWeek[weekdays(prevHospWeek) == HOSPITALIZATIONS_TARGET_DAY]
-}
-
-dash_type_toggle <- function(curr_val, arch_val) {
-  switch(DASH_TYPE,
-         current = curr_val,
-         archive = arch_val
-  )
 }

--- a/app/server.R
+++ b/app/server.R
@@ -730,51 +730,49 @@ server <- function(input, output, session) {
     }
   })
 
-  observeEvent(input$scoreType,
-    {
-      if (input$targetVariable == "Deaths") {
-        df <- df %>% filter(signal == DEATH_FILTER)
-      } else if (input$targetVariable == "Cases") {
-        df <- df %>% filter(signal == CASE_FILTER)
-      } else {
-        df <- df %>% filter(signal == HOSPITALIZATIONS_FILTER)
-      }
-      # Only show forecasters that have data for the score chosen
-      updateForecasterChoices(session, df, input$forecasters, input$scoreType)
-
-      # If we are switching between coverage and other score types we need to
-      # update the as of data we have so it matches the correct locations shown
-      if (input$location == "US") {
-        updateAsOfData()
-      }
-
-      if (input$scoreType == "wis") {
-        showElement(paste0("wisExplanation", DASH_SUFFIX))
-        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-        hideElement(paste0("aeExplanation", DASH_SUFFIX))
-        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-      }
-      if (input$scoreType == "sharpness") {
-        showElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-        hideElement(paste0("wisExplanation", DASH_SUFFIX))
-        hideElement(paste0("aeExplanation", DASH_SUFFIX))
-        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-      }
-      if (input$scoreType == "ae") {
-        hideElement(paste0("wisExplanation", DASH_SUFFIX))
-        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-        showElement(paste0("aeExplanation", DASH_SUFFIX))
-        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-      }
-      if (input$scoreType == "coverage") {
-        hideElement(paste0("wisExplanation", DASH_SUFFIX))
-        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-        hideElement(paste0("aeExplanation", DASH_SUFFIX))
-        showElement(paste0("coverageExplanation", DASH_SUFFIX))
-      }
-      USE_CURR_TRUTH <<- TRUE
+  observeEvent(input$scoreType, {
+    if (input$targetVariable == "Deaths") {
+      df <- df %>% filter(signal == DEATH_FILTER)
+    } else if (input$targetVariable == "Cases") {
+      df <- df %>% filter(signal == CASE_FILTER)
+    } else {
+      df <- df %>% filter(signal == HOSPITALIZATIONS_FILTER)
     }
-  )
+    # Only show forecasters that have data for the score chosen
+    updateForecasterChoices(session, df, input$forecasters, input$scoreType)
+
+    # If we are switching between coverage and other score types we need to
+    # update the as of data we have so it matches the correct locations shown
+    if (input$location == "US") {
+      updateAsOfData()
+    }
+
+    if (input$scoreType == "wis") {
+      showElement(paste0("wisExplanation", DASH_SUFFIX))
+      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+      hideElement(paste0("aeExplanation", DASH_SUFFIX))
+      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
+    }
+    if (input$scoreType == "sharpness") {
+      showElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+      hideElement(paste0("wisExplanation", DASH_SUFFIX))
+      hideElement(paste0("aeExplanation", DASH_SUFFIX))
+      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
+    }
+    if (input$scoreType == "ae") {
+      hideElement(paste0("wisExplanation", DASH_SUFFIX))
+      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+      showElement(paste0("aeExplanation", DASH_SUFFIX))
+      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
+    }
+    if (input$scoreType == "coverage") {
+      hideElement(paste0("wisExplanation", DASH_SUFFIX))
+      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+      hideElement(paste0("aeExplanation", DASH_SUFFIX))
+      showElement(paste0("coverageExplanation", DASH_SUFFIX))
+    }
+    USE_CURR_TRUTH <<- TRUE
+  })
 
   # When forecaster selections change, update available aheads, locations, and CIs to choose from
   observeEvent(input$forecasters, {

--- a/app/server.R
+++ b/app/server.R
@@ -669,7 +669,7 @@ server <- function(input, output, session) {
     ## Filtering DF
     df <- df %>% filter(signal == FILTER)
 
-    ## Update available opitions
+    ## Update available options
     updateAheadChoices(session, df, input$targetVariable, input$forecasters, input$aheads, TRUE)
     updateForecasterChoices(session, df, input$forecasters, input$scoreType)
     updateLocationChoices(session, df, input$targetVariable, input$forecasters, input$location)
@@ -699,8 +699,7 @@ server <- function(input, output, session) {
     ## Storing current target
     PREV_TARGET <<- input$targetVariable
 
-    ## do calling the api if we need as of data
-    ## otherwise we don't need to call it
+    ## Call the API only if we need as of data
     if (updateAsOf) {
       updateAsOfData(fetchDate = currentFetch)
     }

--- a/app/server.R
+++ b/app/server.R
@@ -149,7 +149,7 @@ server <- function(input, output, session) {
     # Need to do this after setting dfWithForecasts to leave in aheads for forecasts
     filteredScoreDf <- filteredScoreDf %>% filter(ahead %in% input$aheads)
     if (nrow(filteredScoreDf) == 0) {
-      output$renderWarningText <- output$renderWarningText_archive <- renderText(paste0(
+      output[[paste0("renderWarningText", DASH_SUFFIX)]] <- renderText(paste0(
         "The selected forecasters do not have enough data ",
         "to display the selected scoring metric."
       ))
@@ -195,25 +195,25 @@ server <- function(input, output, session) {
       aggregateText <- "*For fair comparison, all displayed forecasters on all displayed dates are compared across a common set of states and territories."
       if (input$scoreType == "coverage") {
         aggregate <- "Averaged"
-        output$renderAggregateText <- output$renderAggregateText_archive <- renderText(paste(
+        output[[paste0("renderAggregateText", DASH_SUFFIX)]] <- renderText(paste(
           aggregateText,
           " Some forecasters may not have any data for the coverage interval chosen. Locations inlcuded: "
         ))
       } else {
         aggregate <- "Totaled"
-        output$renderAggregateText <- output$renderAggregateText_archive <- renderText(paste(aggregateText, " Locations included: "))
+        output[[paste0("renderAggregateText", DASH_SUFFIX)]] <- renderText(paste(aggregateText, " Locations included: "))
       }
       if (length(locationsIntersect) == 0) {
-        output$renderWarningText <- output$renderWarningText_archive <- renderText("The selected forecasters do not have data for any locations in common on all dates.")
-        output$renderLocations <- output$renderLocations_archive <- renderText("")
-        output$renderAggregateText <- output$renderAggregateText_archive <- renderText("")
+        output[[paste0("renderWarningText", DASH_SUFFIX)]] <- renderText("The selected forecasters do not have data for any locations in common on all dates.")
+        output[[paste0("renderLocations", DASH_SUFFIX)]] <- renderText("")
+        output[[paste0("renderAggregateText", DASH_SUFFIX)]] <- renderText("")
         hideElement(paste0("truthPlot", DASH_SUFFIX))
         hideElement(paste0("refresh-colors", DASH_SUFFIX))
         return()
       } else {
         locationSubtitleText <- paste0(", Location: ", aggregate, " over all states and territories common to these forecasters*")
-        output$renderLocations <- output$renderLocations_archive <- renderText(toupper(locationsIntersect))
-        output$renderWarningText <- output$renderWarningText_archive <- renderText("")
+        output[[paste0("renderLocations", DASH_SUFFIX)]] <- renderText(toupper(locationsIntersect))
+        output[[paste0("renderWarningText", DASH_SUFFIX)]] <- renderText("")
         showElement(paste0("truthPlot", DASH_SUFFIX))
       }
       # Not totaling over all locations
@@ -230,9 +230,9 @@ server <- function(input, output, session) {
           summarize(Score = Score, actual = actual)
       }
       locationSubtitleText <- paste0(", Location: ", input$location)
-      output$renderAggregateText <- output$renderAggregateText_archive <- renderText("")
-      output$renderLocations <- output$renderLocations_archive <- renderText("")
-      output$renderWarningText <- output$renderWarningText_archive <- renderText("")
+      output[[paste0("renderAggregateText", DASH_SUFFIX)]] <- renderText("")
+      output[[paste0("renderLocations", DASH_SUFFIX)]] <- renderText("")
+      output[[paste0("renderWarningText", DASH_SUFFIX)]] <- renderText("")
     }
 
     showElement(paste0("refresh-colors", DASH_SUFFIX))
@@ -270,22 +270,21 @@ server <- function(input, output, session) {
 
     # Render truth plot with observed values
     truthDf <- filteredScoreDf
-
     ## this first condition is necessary when loading the dash
     if (input$asOf == "") {
       TRUTH_PLOT <<- truthPlot(truthDf, locationsIntersect, !is.null(asOfData), dfWithForecasts, colorPalette)
-      output$truthPlot <- output$truthPlot_archive <- renderPlotly({
+      output[[paste0("truthPlot", DASH_SUFFIX)]] <- renderPlotly({
         TRUTH_PLOT
       })
     } else {
       if (USE_CURR_TRUTH && input$showForecasts == FALSE) {
         # Render existing truth plot
-        output$truthPlot <- output$truthPlot_archive <- renderPlotly({
+        output[[paste0("truthPlot", DASH_SUFFIX)]] <- renderPlotly({
           TRUTH_PLOT
         })
       } else {
         TRUTH_PLOT <<- truthPlot(truthDf, locationsIntersect, !is.null(asOfData), dfWithForecasts, colorPalette)
-        output$truthPlot <- output$truthPlot_archive <- renderPlotly({
+        output[[paste0("truthPlot", DASH_SUFFIX)]] <- renderPlotly({
           TRUTH_PLOT
         })
       }
@@ -663,7 +662,6 @@ server <- function(input, output, session) {
         )
         DASH_SUFFIX <<- "_archive"
       }
-
       updateTargetChoices(session, choices)
     },
     ignoreInit = TRUE

--- a/app/server.R
+++ b/app/server.R
@@ -655,14 +655,15 @@ server <- function(input, output, session) {
           "Hospital Admissions" = "Hospitalizations"
         )
         DASH_SUFFIX <<- ""
+        updateTargetChoices(session, choices)
       } else if (input$tabset == "evaluations_archive") {
         choices <- list(
           "Incident Deaths" = "Deaths",
           "Incident Cases" = "Cases"
         )
         DASH_SUFFIX <<- "_archive"
+        updateTargetChoices(session, choices)
       }
-      updateTargetChoices(session, choices)
     },
     ignoreInit = TRUE
   )

--- a/app/server.R
+++ b/app/server.R
@@ -23,7 +23,7 @@ updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices
   df <- df %>% filter(forecaster %in% forecasterChoices)
   df <- Filter(function(x) !all(is.na(x)), df)
   coverageChoices <- intersect(colnames(df), COVERAGE_INTERVALS)
-  # Ensure previsouly selected options are still allowed
+  # Ensure previously selected options are still allowed
   if (coverageInput %in% coverageChoices) {
     selectedCoverage <- coverageInput
   } else if ("95" %in% coverageChoices) {
@@ -107,6 +107,7 @@ server <- function(input, output, session) {
   AS_OF_CHOICES <- reactiveVal(NULL)
   SUMMARIZING_OVER_ALL_LOCATIONS <- reactive(input$scoreType == "coverage" || input$location == TOTAL_LOCATIONS)
 
+  DASH_SUFFIX <- ""
   COLOR_SEED <- reactiveVal(171)
 
   CURRENT_WEEK_END_DATE <- reactiveVal(CASES_DEATHS_CURRENT)
@@ -206,14 +207,14 @@ server <- function(input, output, session) {
         output$renderWarningText <- output$renderWarningText_archive <- renderText("The selected forecasters do not have data for any locations in common on all dates.")
         output$renderLocations <- output$renderLocations_archive <- renderText("")
         output$renderAggregateText <- output$renderAggregateText_archive <- renderText("")
-        hideElement("truthPlot")
-        hideElement("refresh-colors")
+        hideElement(paste0("truthPlot", DASH_SUFFIX))
+        hideElement(paste0("refresh-colors", DASH_SUFFIX))
         return()
       } else {
         locationSubtitleText <- paste0(", Location: ", aggregate, " over all states and territories common to these forecasters*")
         output$renderLocations <- output$renderLocations_archive <- renderText(toupper(locationsIntersect))
         output$renderWarningText <- output$renderWarningText_archive <- renderText("")
-        showElement("truthPlot")
+        showElement(paste0("truthPlot", DASH_SUFFIX))
       }
       # Not totaling over all locations
     } else {
@@ -234,7 +235,7 @@ server <- function(input, output, session) {
       output$renderWarningText <- output$renderWarningText_archive <- renderText("")
     }
 
-    showElement("refresh-colors")
+    showElement(paste0("refresh-colors", DASH_SUFFIX))
     if (nrow(filteredScoreDf) == 0) {
       # no data to show
       return()
@@ -654,11 +655,13 @@ server <- function(input, output, session) {
         choices <- list(
           "Hospital Admissions" = "Hospitalizations"
         )
+        DASH_SUFFIX <<- ""
       } else if (input$tabset == "evaluations_archive") {
         choices <- list(
           "Incident Deaths" = "Deaths",
           "Incident Cases" = "Cases"
         )
+        DASH_SUFFIX <<- "_archive"
       }
 
       updateTargetChoices(session, choices)
@@ -666,7 +669,7 @@ server <- function(input, output, session) {
     ignoreInit = TRUE
   )
 
-  observeEvent(input$refreshColors,
+  observeEvent(input$refreshColors | input$refreshColors_archive,
     {
       COLOR_SEED(floor(runif(1, 1, 1000)))
       USE_CURR_TRUTH <<- TRUE
@@ -746,32 +749,31 @@ server <- function(input, output, session) {
       }
 
       if (input$scoreType == "wis") {
-        showElement("wisExplanation")
-        hideElement("sharpnessExplanation")
-        hideElement("aeExplanation")
-        hideElement("coverageExplanation")
+        showElement(paste0("wisExplanation", DASH_SUFFIX))
+        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+        hideElement(paste0("aeExplanation", DASH_SUFFIX))
+        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
       }
       if (input$scoreType == "sharpness") {
-        showElement("sharpnessExplanation")
-        hideElement("wisExplanation")
-        hideElement("aeExplanation")
-        hideElement("coverageExplanation")
+        showElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+        hideElement(paste0("wisExplanation", DASH_SUFFIX))
+        hideElement(paste0("aeExplanation", DASH_SUFFIX))
+        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
       }
       if (input$scoreType == "ae") {
-        hideElement("wisExplanation")
-        hideElement("sharpnessExplanation")
-        showElement("aeExplanation")
-        hideElement("coverageExplanation")
+        hideElement(paste0("wisExplanation", DASH_SUFFIX))
+        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+        showElement(paste0("aeExplanation", DASH_SUFFIX))
+        hideElement(paste0("coverageExplanation", DASH_SUFFIX))
       }
       if (input$scoreType == "coverage") {
-        hideElement("wisExplanation")
-        hideElement("sharpnessExplanation")
-        hideElement("aeExplanation")
-        showElement("coverageExplanation")
+        hideElement(paste0("wisExplanation", DASH_SUFFIX))
+        hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
+        hideElement(paste0("aeExplanation", DASH_SUFFIX))
+        showElement(paste0("coverageExplanation", DASH_SUFFIX))
       }
       USE_CURR_TRUTH <<- TRUE
-    },
-    ignoreInit = TRUE
+    }
   )
 
   # When forecaster selections change, update available aheads, locations, and CIs to choose from
@@ -825,11 +827,11 @@ server <- function(input, output, session) {
   observe({
     # Show data loading message and hide other messages until all data is loaded
     if (DATA_LOADED) {
-      hideElement("data-loading-message")
-      showElement("refresh-colors")
-      showElement("notes")
-      showElement("scoreExplanations")
-      showElement("scoringDisclaimer")
+      hideElement(paste0("data-loading-message", DASH_SUFFIX))
+      showElement(paste0("refresh-colors", DASH_SUFFIX))
+      showElement(paste0("notes", DASH_SUFFIX))
+      showElement(paste0("scoreExplanations", DASH_SUFFIX))
+      showElement(paste0("scoringDisclaimer", DASH_SUFFIX))
     }
     # Ensure there is always one ahead selected
     if (length(input$aheads) < 1) {
@@ -876,13 +878,13 @@ server <- function(input, output, session) {
     }
 
     if (fetchDate < CURRENT_WEEK_END_DATE()) {
-      hideElement("truthPlot")
-      hideElement("notes")
-      hideElement("scoringDisclaimer")
-      hideElement("scoreExplanations")
-      hideElement("renderAggregateText")
-      hideElement("renderLocations")
-      showElement("truth-plot-loading-message")
+      hideElement(paste0("truthPlot", DASH_SUFFIX))
+      hideElement(paste0("notes", DASH_SUFFIX))
+      hideElement(paste0("scoringDisclaimer", DASH_SUFFIX))
+      hideElement(paste0("scoreExplanations", DASH_SUFFIX))
+      hideElement(paste0("renderAggregateText", DASH_SUFFIX))
+      hideElement(paste0("renderLocations", DASH_SUFFIX))
+      showElement(paste0("truth-plot-loading-message", DASH_SUFFIX))
 
       # Since as_of matches to the issue date in covidcast (rather than the time_value)
       # we need to add one extra day to get the as of we want.
@@ -895,13 +897,13 @@ server <- function(input, output, session) {
         as_of = fetchDate,
         geo_type = location
       )
-      showElement("truthPlot")
-      showElement("notes")
-      showElement("scoringDisclaimer")
-      showElement("scoreExplanations")
-      showElement("renderAggregateText")
-      showElement("renderLocations")
-      hideElement("truth-plot-loading-message")
+      showElement(paste0("truthPlot", DASH_SUFFIX))
+      showElement(paste0("notes", DASH_SUFFIX))
+      showElement(paste0("scoringDisclaimer", DASH_SUFFIX))
+      showElement(paste0("scoreExplanations", DASH_SUFFIX))
+      showElement(paste0("renderAggregateText", DASH_SUFFIX))
+      showElement(paste0("renderLocations", DASH_SUFFIX))
+      hideElement(paste0("truth-plot-loading-message", DASH_SUFFIX))
       PREV_AS_OF_DATA(asOfTruthData)
 
       if (nrow(asOfTruthData) == 0) {

--- a/app/server.R
+++ b/app/server.R
@@ -144,7 +144,7 @@ server <- function(input, output, session) {
     # Need to do this after setting dfWithForecasts to leave in aheads for forecasts
     filteredScoreDf <- filteredScoreDf %>% filter(ahead %in% input$aheads)
     if (nrow(filteredScoreDf) == 0) {
-      output$renderWarningText <- renderText(paste0(
+      output$renderWarningText <- output$renderWarningText_archive <- renderText(paste0(
         "The selected forecasters do not have enough data ",
         "to display the selected scoring metric."
       ))
@@ -190,25 +190,25 @@ server <- function(input, output, session) {
       aggregateText <- "*For fair comparison, all displayed forecasters on all displayed dates are compared across a common set of states and territories."
       if (input$scoreType == "coverage") {
         aggregate <- "Averaged"
-        output$renderAggregateText <- renderText(paste(
+        output$renderAggregateText <- output$renderAggregateText_archive <- renderText(paste(
           aggregateText,
           " Some forecasters may not have any data for the coverage interval chosen. Locations inlcuded: "
         ))
       } else {
         aggregate <- "Totaled"
-        output$renderAggregateText <- renderText(paste(aggregateText, " Locations included: "))
+        output$renderAggregateText <- output$renderAggregateText_archive <- renderText(paste(aggregateText, " Locations included: "))
       }
       if (length(locationsIntersect) == 0) {
-        output$renderWarningText <- renderText("The selected forecasters do not have data for any locations in common on all dates.")
-        output$renderLocations <- renderText("")
-        output$renderAggregateText <- renderText("")
+        output$renderWarningText <- output$renderWarningText_archive <- renderText("The selected forecasters do not have data for any locations in common on all dates.")
+        output$renderLocations <- output$renderLocations_archive <- renderText("")
+        output$renderAggregateText <- output$renderAggregateText_archive <- renderText("")
         hideElement("truthPlot")
         hideElement("refresh-colors")
         return()
       } else {
         locationSubtitleText <- paste0(", Location: ", aggregate, " over all states and territories common to these forecasters*")
-        output$renderLocations <- renderText(toupper(locationsIntersect))
-        output$renderWarningText <- renderText("")
+        output$renderLocations <- output$renderLocations_archive <- renderText(toupper(locationsIntersect))
+        output$renderWarningText <- output$renderWarningText_archive <- renderText("")
         showElement("truthPlot")
       }
       # Not totaling over all locations
@@ -225,9 +225,9 @@ server <- function(input, output, session) {
           summarize(Score = Score, actual = actual)
       }
       locationSubtitleText <- paste0(", Location: ", input$location)
-      output$renderAggregateText <- renderText("")
-      output$renderLocations <- renderText("")
-      output$renderWarningText <- renderText("")
+      output$renderAggregateText <- output$renderAggregateText_archive <- renderText("")
+      output$renderLocations <- output$renderLocations_archive <- renderText("")
+      output$renderWarningText <- output$renderWarningText_archive <- renderText("")
     }
 
     showElement("refresh-colors")
@@ -269,18 +269,18 @@ server <- function(input, output, session) {
     ## this first condition is necessary when loading the dash
     if (input$asOf == "") {
       TRUTH_PLOT <<- truthPlot(truthDf, locationsIntersect, !is.null(asOfData), dfWithForecasts, colorPalette)
-      output$truthPlot <- renderPlotly({
+      output$truthPlot <- output$truthPlot_archive <- renderPlotly({
         TRUTH_PLOT
       })
     } else {
       if (USE_CURR_TRUTH && input$showForecasts == FALSE) {
         # Render existing truth plot
-        output$truthPlot <- renderPlotly({
+        output$truthPlot <- output$truthPlot_archive <- renderPlotly({
           TRUTH_PLOT
         })
       } else {
         TRUTH_PLOT <<- truthPlot(truthDf, locationsIntersect, !is.null(asOfData), dfWithForecasts, colorPalette)
-        output$truthPlot <- renderPlotly({
+        output$truthPlot <- output$truthPlot_archive <- renderPlotly({
           TRUTH_PLOT
         })
       }
@@ -476,7 +476,7 @@ server <- function(input, output, session) {
   #############
   # PLOT OUTPUT
   #############
-  output$summaryPlot <- renderPlotly({
+  output$summaryPlot <- output$summaryPlot_archive <- renderPlotly({
     summaryPlot()
   })
 

--- a/app/server.R
+++ b/app/server.R
@@ -1,6 +1,10 @@
 ################
 # UTIL FUNCTIONS before server definition
 ################
+updateTargetChoices <- function(session, targetChoices) {
+  updateRadioButtons(session, "targetVariable", choices = targetChoices)
+}
+
 updateForecasterChoices <- function(session, df, forecasterInput, scoreType) {
   if (scoreType == "wis") {
     df <- df %>% filter(!is.na(wis))
@@ -643,6 +647,24 @@ server <- function(input, output, session) {
   ###################
   # EVENT OBSERVATION
   ###################
+
+  observeEvent(input$tabset,
+    {
+      if (input$tabset == "evaluations") {
+        choices <- list(
+          "Hospital Admissions" = "Hospitalizations"
+        )
+      } else if (input$tabset == "evaluations_archive") {
+        choices <- list(
+          "Incident Deaths" = "Deaths",
+          "Incident Cases" = "Cases"
+        )
+      }
+
+      updateTargetChoices(session, choices)
+    },
+    ignoreInit = TRUE
+  )
 
   observeEvent(input$refreshColors,
     {

--- a/app/ui.R
+++ b/app/ui.R
@@ -58,14 +58,8 @@ sidebar <- tags$div(
   conditionalPanel(
     condition = "input.tabset == 'evaluations' | input.tabset == 'evaluations_archive'",
     radioButtons("targetVariable", "Target Variable",
-      choices = dash_type_toggle(
-        curr_val = list(
-          "Hospital Admissions" = "Hospitalizations"
-        ),
-        arch_val = list(
-          "Incident Deaths" = "Deaths",
-          "Incident Cases" = "Cases"
-        )
+      choices = list(
+        "Hospital Admissions" = "Hospitalizations"
       )
     ),
     radioButtons("scoreType", "Scoring Metric",

--- a/app/ui.R
+++ b/app/ui.R
@@ -13,9 +13,50 @@ aboutDashboardText <- includeMarkdown("assets/about-dashboard.md")
 # Layout
 ########
 
+create_output_panel <- function(title, suffix) {
+  tabPanel(title,
+    value = paste0("evaluations", suffix),
+    fluidRow(column(11, textOutput(paste0("renderWarningText", suffix)))),
+    plotlyOutput(outputId = paste0("summaryPlot", suffix), height = "auto"),
+    fluidRow(
+      column(11,
+        offset = 1,
+        hidden(div(id = "refresh-colors", actionButton(inputId = paste0("refreshColors", suffix), label = "Recolor")))
+      )
+    ),
+    tags$br(),
+    plotlyOutput(outputId = paste0("truthPlot", suffix), height = "auto"),
+    fluidRow(
+      column(11,
+        offset = 1,
+        div(id = "data-loading-message", "DATA IS LOADING...(this may take a while)"),
+        hidden(div(id = paste0("truth-plot-loading-message", suffix), "Fetching 'as of' data and loading observed values...")),
+        hidden(div(id = paste0("notes", suffix), "About the Scores")),
+        hidden(div(
+          id = "scoreExplanations",
+          hidden(div(id = paste0("wisExplanation", suffix), wisExplanation)),
+          hidden(div(id = paste0("sharpnessExplanation", suffix), sharpnessExplanation)),
+          hidden(div(id = paste0("aeExplanation", suffix), aeExplanation)),
+          hidden(div(id = paste0("coverageExplanation", suffix), coverageExplanation))
+        )),
+        hidden(div(id = paste0("scoringDisclaimer", suffix), scoringDisclaimer))
+      )
+    ),
+    fluidRow(
+      column(11,
+        offset = 1,
+        textOutput(paste0("renderLocationText", suffix)),
+        textOutput(paste0("renderAggregateText", suffix)),
+        textOutput(paste0("renderLocations", suffix)),
+        tags$br()
+      )
+    )
+  )
+}
+
 sidebar <- tags$div(
   conditionalPanel(
-    condition = "input.tabset == 'evaluations'",
+    condition = "input.tabset == 'evaluations' | input.tabset == 'evaluations_archive'",
     radioButtons("targetVariable", "Target Variable",
       choices = dash_type_toggle(
         curr_val = list(
@@ -140,44 +181,8 @@ main <- tabsetPanel(
       tags$br()
     )),
   ),
-  tabPanel("Evaluation Plots",
-    value = "evaluations",
-    fluidRow(column(11, textOutput("renderWarningText"))),
-    plotlyOutput(outputId = "summaryPlot", height = "auto"),
-    fluidRow(
-      column(11,
-        offset = 1,
-        hidden(div(id = "refresh-colors", actionButton(inputId = "refreshColors", label = "Recolor")))
-      )
-    ),
-    tags$br(),
-    plotlyOutput(outputId = "truthPlot", height = "auto"),
-    fluidRow(
-      column(11,
-        offset = 1,
-        div(id = "data-loading-message", "DATA IS LOADING...(this may take a while)"),
-        hidden(div(id = "truth-plot-loading-message", "Fetching 'as of' data and loading observed values...")),
-        hidden(div(id = "notes", "About the Scores")),
-        hidden(div(
-          id = "scoreExplanations",
-          hidden(div(id = "wisExplanation", wisExplanation)),
-          hidden(div(id = "sharpnessExplanation", sharpnessExplanation)),
-          hidden(div(id = "aeExplanation", aeExplanation)),
-          hidden(div(id = "coverageExplanation", coverageExplanation))
-        )),
-        hidden(div(id = "scoringDisclaimer", scoringDisclaimer))
-      )
-    ),
-    fluidRow(
-      column(11,
-        offset = 1,
-        textOutput("renderLocationText"),
-        textOutput("renderAggregateText"),
-        textOutput("renderLocations"),
-        tags$br()
-      )
-    )
-  )
+  create_output_panel("Evaluation Plots", ""),
+  create_output_panel("Archive Evaluation Plots", "_archive")
 )
 
 ui <- delphiLayoutUI(

--- a/app/ui.R
+++ b/app/ui.R
@@ -56,7 +56,8 @@ create_output_panel <- function(title, suffix) {
 
 sidebar <- tags$div(
   conditionalPanel(
-    condition = "input.tabset == 'evaluations' | input.tabset == 'evaluations_archive'",
+    # NB conditions are written in JavaScript!!
+    condition = "input.tabset.startsWith('evaluations')",
     radioButtons("targetVariable", "Target Variable",
       choices = list(
         "Hospital Admissions" = "Hospitalizations"

--- a/app/ui.R
+++ b/app/ui.R
@@ -53,7 +53,7 @@ sidebar <- tags$div(
     selectInput(
       "forecasters",
       tags$div("Forecasters", tags$div(id = "forecaster-input", "Type a name or select from dropdown")),
-      choices = c("COVIDhub-baseline", "COVIDhub-4weekensemble"),
+      choices = c("COVIDhub-baseline", "COVIDhub-4_week_ensemble"),
       multiple = TRUE,
       selected = c("COVIDhub-baseline", "COVIDhub-4_week_ensemble")
     ),

--- a/app/ui.R
+++ b/app/ui.R
@@ -17,10 +17,14 @@ sidebar <- tags$div(
   conditionalPanel(
     condition = "input.tabset == 'evaluations'",
     radioButtons("targetVariable", "Target Variable",
-      choices = list(
-        "Incident Deaths" = "Deaths",
-        "Incident Cases" = "Cases",
-        "Hospital Admissions" = "Hospitalizations"
+      choices = dash_type_toggle(
+        curr_val = list(
+          "Hospital Admissions" = "Hospitalizations"
+        ),
+        arch_val = list(
+          "Incident Deaths" = "Deaths",
+          "Incident Cases" = "Cases"
+        )
       )
     ),
     radioButtons("scoreType", "Scoring Metric",
@@ -49,9 +53,9 @@ sidebar <- tags$div(
     selectInput(
       "forecasters",
       tags$div("Forecasters", tags$div(id = "forecaster-input", "Type a name or select from dropdown")),
-      choices = c("COVIDhub-baseline", "COVIDhub-ensemble"),
+      choices = c("COVIDhub-baseline", "COVIDhub-4weekensemble"),
       multiple = TRUE,
-      selected = c("COVIDhub-baseline", "COVIDhub-ensemble")
+      selected = c("COVIDhub-baseline", "COVIDhub-4_week_ensemble")
     ),
     tags$p(
       id = "missing-data-disclaimer",

--- a/app/ui.R
+++ b/app/ui.R
@@ -21,7 +21,7 @@ create_output_panel <- function(title, suffix) {
     fluidRow(
       column(11,
         offset = 1,
-        hidden(div(id = "refresh-colors", actionButton(inputId = paste0("refreshColors", suffix), label = "Recolor")))
+        hidden(div(id = paste0("refresh-colors", suffix), actionButton(inputId = paste0("refreshColors", suffix), label = "Recolor")))
       )
     ),
     tags$br(),
@@ -29,11 +29,11 @@ create_output_panel <- function(title, suffix) {
     fluidRow(
       column(11,
         offset = 1,
-        div(id = "data-loading-message", "DATA IS LOADING...(this may take a while)"),
+        div(id = paste0("data-loading-message", suffix), "DATA IS LOADING...(this may take a while)"),
         hidden(div(id = paste0("truth-plot-loading-message", suffix), "Fetching 'as of' data and loading observed values...")),
         hidden(div(id = paste0("notes", suffix), "About the Scores")),
         hidden(div(
-          id = "scoreExplanations",
+          id = paste0("scoreExplanations", suffix),
           hidden(div(id = paste0("wisExplanation", suffix), wisExplanation)),
           hidden(div(id = paste0("sharpnessExplanation", suffix), sharpnessExplanation)),
           hidden(div(id = paste0("aeExplanation", suffix), aeExplanation)),

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -6,7 +6,7 @@
 #aboutContentArea{
     max-width: 70rem;
 }
-#notes {
+#notes, #notes_archive {
     font-weight: 600;
     font-size: 18px;
 }
@@ -25,11 +25,11 @@
 #drag-to-zoom {
     font-size:11px;
 }
-#data-loading-message {
+#data-loading-message, #data-loading-message_archive {
     font-style: italic;
     font-size: 18px;
 }
-#truth-plot-loading-message {
+#truth-plot-loading-message, #truth-plot-loading-message_archive {
     margin-top:50px;
     font-size: 18px;
     font-style:italic;


### PR DESCRIPTION
### Description
Since JHU has been discontinued, forecasts using it as truth data (for plotting and for scoring) are no longer supported by ForecastHub. Forecasts for cases and deaths are moving to "archival" status and should be differentiated from the active target variable hospital admissions.

To do so, cases and deaths forecasts will be displayed in a separate tab on the dashboard. Since we want to have the new tab use the same/existing format as the "current" tab, the data handling and plotting logic will be shared.

IDs of objects in the dashboard (plots, text, buttons) must be unique, so to reuse the code in a general way, modify interactive object IDs by appending a tab-dependent suffix. Add reactivity to support this.

Note:
- At the moment, this new tabbed dashboard fetches all the data on load. This will be improved in an upcoming PR.
- The separate-dashboards version of this is working at commit [fe4f6b7](https://github.com/cmu-delphi/forecast-eval/pull/253/commits/fe4f6b73d1ae90f5a6b6805e32f88ee4a883e295).

### Changes
- Makefile -- set working dir for easier local runs
- `data.R` -- simplify data load
- `server.R` -- observe tab change; send results to tab-appropriate output ids
- `ui.R` -- factor out plot area layout and reuse for "archive" tab
- `style.css` -- apply the same formatting to the "archive" tab

### Fixes
Partially addresses https://github.com/cmu-delphi/forecast-eval/issues/175