### PR TITLE
Load and cache target variable data separately

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
  covidcast,
  stringr,
  markdown,
- memoise
+ memoise,
+ purrr
 Suggests:
  styler,
  lintr,

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -68,8 +68,7 @@ getCreationDate <- function(loadFile) {
 
 
 getAllData <- function(loadFile, targetVariable) {
-  df <- switch(
-    targetVariable,
+  df <- switch(targetVariable,
     "Deaths" = bind_rows(
       loadFile("score_cards_state_deaths.rds"),
       loadFile("score_cards_nation_deaths.rds")
@@ -83,7 +82,7 @@ getAllData <- function(loadFile, targetVariable) {
       loadFile("score_cards_nation_hospitalizations.rds")
     )
   )
-  
+
   # Pick out expected columns only
   expectedCols <- c(
     "ahead", "geo_value", "forecaster", "forecast_date",
@@ -119,8 +118,8 @@ createS3DataLoader <- function() {
     # bucket and request, including bucket region, name, content type, request
     # date, request ID, etc.
     if (!(targetVariable %in% names(df_list)) ||
-        nrow(df_list[[targetVariable]]) == 0 ||
-        !identical(s3Contents, newS3Contents)) {
+      nrow(df_list[[targetVariable]]) == 0 ||
+      !identical(s3Contents, newS3Contents)) {
       # Save new data and new bucket connection info to vars in env of
       # `createS3DataLoader`. They persist between calls to `getRecentData` a
       # la https://stackoverflow.com/questions/1088639/static-variables-in-r

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -105,7 +105,7 @@ createS3DataLoader <- function() {
   df_list <- list()
   dataCreationDate <- as.Date(NA)
 
-  getRecentData <- function(targetVariable = c("Deaths", "Cases", "Hospitalizations")) {
+  getRecentData <- function(targetVariable = TARGET_OPTIONS) {
     targetVariable <- match.arg(targetVariable)
 
     newS3bucket <- getS3Bucket()
@@ -137,12 +137,17 @@ createS3DataLoader <- function() {
 
 #' create a data loader with fallback data only
 createFallbackDataLoader <- function() {
-  df_list <- getAllData(getFallbackData)
+  df_list <- list()
+  for (targetVariable in TARGET_OPTIONS) {
+    df_list[[targetVariable]] <- getAllData(getFallbackData, targetVariable)
+  }
+  dataCreationDate <- getCreationDate(getFallbackData)
 
   dataLoader <- function() {
-    df_list
+    return(list(df_list = df_list, dataCreationDate = dataCreationDate))
   }
-  dataLoader
+
+  return(dataLoader)
 }
 
 

--- a/app/R/exportScores.R
+++ b/app/R/exportScores.R
@@ -6,18 +6,14 @@ exportScoresUI <- function(id = "exportScores") {
 }
 
 createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, forecasters, loc, coverageInterval) {
-  signalFilter <- CASE_FILTER
-  if (targetVariable == "Deaths") {
-    signalFilter <- DEATH_FILTER
-  } else if (targetVariable == "Hospitalizations") {
-    signalFilter <- HOSPITALIZATIONS_FILTER
-  }
+  scoreDf <- filter(
+    scoreDf[[targetVariable]],
+    forecaster %in% forecasters
+  )
   scoreDf <- renameScoreCol(scoreDf, scoreType, coverageInterval)
-  scoreDf <- scoreDf %>%
-    filter(signal == signalFilter) %>%
-    filter(forecaster %in% forecasters)
+
   if (loc == TOTAL_LOCATIONS || scoreType == "coverage") {
-    if (signalFilter == HOSPITALIZATIONS_FILTER) {
+    if (targetVariable == "Hospitalizations") {
       scoreDf <- filterHospitalizationsAheads(scoreDf)
     }
     scoreDf <- filterOverAllLocations(scoreDf, scoreType)

--- a/app/global.R
+++ b/app/global.R
@@ -2,6 +2,7 @@ library(shiny)
 library(shinyjs)
 library(plotly)
 library(tidyr)
+library(purrr)
 library(dplyr, warn.conflicts = FALSE)
 library(lubridate)
 library(viridis)
@@ -11,10 +12,7 @@ library(covidcast)
 appVersion <- "6.0.0"
 
 COVERAGE_INTERVALS <- c("10", "20", "30", "40", "50", "60", "70", "80", "90", "95", "98")
-DEATH_FILTER <- "deaths_incidence_num"
-CASE_FILTER <- "confirmed_incidence_num"
 CASES_DEATHS_TARGET_DAY <- "Saturday"
-HOSPITALIZATIONS_FILTER <- "confirmed_admissions_covid_1d"
 HOSPITALIZATIONS_TARGET_DAY <- "Wednesday"
 TOTAL_LOCATIONS <- "Totaled Over States*"
 AHEAD_OPTIONS <- c(1, 2, 3, 4)

--- a/app/global.R
+++ b/app/global.R
@@ -17,6 +17,9 @@ HOSPITALIZATIONS_TARGET_DAY <- "Wednesday"
 TOTAL_LOCATIONS <- "Totaled Over States*"
 AHEAD_OPTIONS <- c(1, 2, 3, 4)
 
+INIT_TARGET <- "Hospitalizations"
+TARGET_OPTIONS <- c("Deaths", "Cases", "Hospitalizations")
+
 # Num days to offset the forecast week by
 # Example: if HOSPITALIZATIONS_TARGET_DAY is Wednesday and HOSPITALIZATIONS_OFFSET is 2,
 # ahead 1 has to have forecast date of Monday or earlier,
@@ -27,8 +30,8 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
-# Sets the previous target to be the same as the first one, Deaths
-PREV_TARGET <- "Deaths"
+# Set the "previous" target to be the starting target variable
+PREV_TARGET <- INIT_TARGET
 
 # When RE_RENDER_TRUTH = TRUE
 # summaryPlot will be called only to update TruthPlot

--- a/app/server.R
+++ b/app/server.R
@@ -113,7 +113,7 @@ server <- function(input, output, session) {
   CURRENT_WEEK_END_DATE <- reactiveVal(CASES_DEATHS_CURRENT)
 
   # Get scores
-  loaded <- loadData()
+  loaded <- loadData("Hospitalizations") # Starting targetVariable.
   df_list <- loaded$df_list
   dataCreationDate <- loaded$dataCreationDate
   DATA_LOADED <- TRUE
@@ -670,9 +670,16 @@ server <- function(input, output, session) {
 
   # When the target variable changes, update available forecasters, locations, and CIs to choose from
   observeEvent(input$targetVariable, {
+    DATA_LOADED <<- FALSE
+
     ## summaryPlot will try to use PREV_AS_OF_DATA()
     ## since it has wrong data information, it needs to be removed
     PREV_AS_OF_DATA(NULL)
+    
+    loaded <<- loadData(input$targetVariable)
+    df_list <<- loaded$df_list
+    dataCreationDate <<- loaded$dataCreationDate
+    DATA_LOADED <<- TRUE
     df <- df_list[[input$targetVariable]]
 
     ## Update available options

--- a/app/server.R
+++ b/app/server.R
@@ -119,8 +119,8 @@ server <- function(input, output, session) {
   DATA_LOADED <- TRUE
 
   # Prepare input choices
-  forecasterChoices <- sort(unique(df_list[["Cases"]][["forecaster"]]))
-  updateForecasterChoices(session, df_list[["Cases"]], forecasterChoices, "wis")
+  forecasterChoices <- sort(unique(df_list[["Hospitalizations"]][["forecaster"]])) # First target var
+  updateForecasterChoices(session, df_list[["Hospitalizations"]], forecasterChoices, "wis") # First target var and score type
 
   ##################
   # CREATE MAIN PLOT
@@ -681,7 +681,7 @@ server <- function(input, output, session) {
     dataCreationDate <<- loaded$dataCreationDate
     DATA_LOADED <<- TRUE
     df <- df_list[[input$targetVariable]]
-
+    
     ## Update available options
     updateAheadChoices(session, df, input$targetVariable, input$forecasters, input$aheads, TRUE)
     updateForecasterChoices(session, df, input$forecasters, input$scoreType)

--- a/app/server.R
+++ b/app/server.R
@@ -78,7 +78,7 @@ updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, a
   }
   aheadChoices <- Filter(function(x) any(unique(df$ahead) %in% x), aheadOptions)
   # Ensure previsouly selected options are still allowed
-  if (!is.null(aheads) && aheads %in% aheadChoices) {
+  if (!is.null(aheads) && all(aheads %in% aheadChoices)) {
     selectedAheads <- aheads
   } else {
     selectedAheads <- aheadOptions[1]

--- a/app/server.R
+++ b/app/server.R
@@ -118,10 +118,6 @@ server <- function(input, output, session) {
   dataCreationDate <- loaded$dataCreationDate
   DATA_LOADED <- TRUE
 
-  # Prepare input choices
-  forecasterChoices <- sort(unique(df_list[["Hospitalizations"]][["forecaster"]])) # First target var
-  updateForecasterChoices(session, df_list[["Hospitalizations"]], forecasterChoices, "wis") # First target var and score type
-
   ##################
   # CREATE MAIN PLOT
   ##################
@@ -129,7 +125,7 @@ server <- function(input, output, session) {
     if (input$location == "") {
       return()
     }
-
+  
     ## Setting target signal to be compared with asOfData
     if (input$targetVariable == "Cases") {
       targetSignal <- "confirmed_incidence_num"
@@ -245,15 +241,15 @@ server <- function(input, output, session) {
       Week_End_Date = target_end_date
     )
 
-    ## Setting color for each forecaster
+    ## Create color palette
     set.seed(COLOR_SEED())
     forecasterRand <- input$forecasters
-    ## If we have less then 5 forecaster selected
-    ## In order to get more different colors when recoloring
-    ## Lets input more forecasters on forecasterRand
-    if (length(forecasterRand) < 8) {
-      nForecast <- 8 - length(forecasterRand)
-      forecasterRand <- c(forecasterRand, forecasterChoices[!forecasterChoices %in% forecasterRand][1:5])
+    # Pad selected forecasters up to 8 items to get more-different colors for a
+    # small number of requested forecasters
+    minForecasters <- 8
+    if (length(forecasterRand) < minForecasters) {
+      nForecasters <- minForecasters - length(forecasterRand)
+      forecasterRand <- c(forecasterRand, paste0("blank_names", 1:nForecasters))
     }
 
     colorPalette <- setNames(
@@ -687,7 +683,7 @@ server <- function(input, output, session) {
     updateForecasterChoices(session, df, input$forecasters, input$scoreType)
     updateLocationChoices(session, df, input$targetVariable, input$forecasters, input$location)
     updateCoverageChoices(session, df, input$targetVariable, input$forecasters, input$coverageInterval, output)
-
+    
     ## updateAsOf sets if we need to call updateAsOfData
     ## the only necessary case is when going from
     ## cases, deaths -> cases,deaths

--- a/app/server.R
+++ b/app/server.R
@@ -125,7 +125,7 @@ server <- function(input, output, session) {
     if (input$location == "") {
       return()
     }
-  
+
     ## Setting target signal to be compared with asOfData
     if (input$targetVariable == "Cases") {
       targetSignal <- "confirmed_incidence_num"
@@ -683,7 +683,7 @@ server <- function(input, output, session) {
     updateForecasterChoices(session, df, input$forecasters, input$scoreType)
     updateLocationChoices(session, df, input$targetVariable, input$forecasters, input$location)
     updateCoverageChoices(session, df, input$targetVariable, input$forecasters, input$coverageInterval, output)
-    
+
     ## updateAsOf sets if we need to call updateAsOfData
     ## the only necessary case is when going from
     ## cases, deaths -> cases,deaths

--- a/app/server.R
+++ b/app/server.R
@@ -113,7 +113,7 @@ server <- function(input, output, session) {
   CURRENT_WEEK_END_DATE <- reactiveVal(CASES_DEATHS_CURRENT)
 
   # Get scores
-  loaded <- loadData("Hospitalizations") # Starting targetVariable.
+  loaded <- loadData(INIT_TARGET)
   df_list <- loaded$df_list
   dataCreationDate <- loaded$dataCreationDate
   DATA_LOADED <- TRUE

--- a/app/server.R
+++ b/app/server.R
@@ -675,13 +675,13 @@ server <- function(input, output, session) {
     ## summaryPlot will try to use PREV_AS_OF_DATA()
     ## since it has wrong data information, it needs to be removed
     PREV_AS_OF_DATA(NULL)
-    
+
     loaded <<- loadData(input$targetVariable)
     df_list <<- loaded$df_list
     dataCreationDate <<- loaded$dataCreationDate
     DATA_LOADED <<- TRUE
     df <- df_list[[input$targetVariable]]
-    
+
     ## Update available options
     updateAheadChoices(session, df, input$targetVariable, input$forecasters, input$aheads, TRUE)
     updateForecasterChoices(session, df, input$forecasters, input$scoreType)
@@ -718,12 +718,11 @@ server <- function(input, output, session) {
     }
   })
 
-  observeEvent(input$scoreType,
-    {
-      df <- df_list[[input$targetVariable]]
+  observeEvent(input$scoreType, {
+    df <- df_list[[input$targetVariable]]
 
-      # Only show forecasters that have data for the score chosen
-      updateForecasterChoices(session, df, input$forecasters, input$scoreType)
+    # Only show forecasters that have data for the score chosen
+    updateForecasterChoices(session, df, input$forecasters, input$scoreType)
 
     # If we are switching between coverage and other score types we need to
     # update the as of data we have so it matches the correct locations shown


### PR DESCRIPTION
### Description
Current behavior is to fetch data for all target variables on dashboard load and `bind` them together. This requires filtering the dataset every time the user selects a new target variable.

Instead, store target variable datasets as elements in a named list and fetch the relevant element by name when the target variable changes. The list elements can be cached incrementally. Simplify target variable-filtering logic in `server.R`.

### Fixes
- Partially addresses https://github.com/cmu-delphi/forecast-eval/issues/174 . Separating data fetch/storage by geo type is not addressed here due to the only small additional benefit that change would provide. Most of the time we're handling state forecasts, both when a single state is requested or when we're summarizing across them; separating out US data only saves effort ~1/60 of the time.
- Closes https://github.com/cmu-delphi/forecast-eval/issues/150