### PR TITLE
Show score explanation when switching to archive tab

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -29,6 +29,8 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
+ARCHIVE_TAB_SUFFIX <- "_archive"
+
 # Sets the "previous" target to be the same as the first one
 PREV_TARGET <- "Hospitalizations"
 

--- a/app/server.R
+++ b/app/server.R
@@ -95,6 +95,33 @@ updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, a
   )
 }
 
+showScoreExplanation <- function(session, scoreType, dash_suffix) {
+  if (scoreType == "wis") {
+    showElement(paste0("wisExplanation", dash_suffix))
+    hideElement(paste0("sharpnessExplanation", dash_suffix))
+    hideElement(paste0("aeExplanation", dash_suffix))
+    hideElement(paste0("coverageExplanation", dash_suffix))
+  }
+  if (scoreType == "sharpness") {
+    showElement(paste0("sharpnessExplanation", dash_suffix))
+    hideElement(paste0("wisExplanation", dash_suffix))
+    hideElement(paste0("aeExplanation", dash_suffix))
+    hideElement(paste0("coverageExplanation", dash_suffix))
+  }
+  if (scoreType == "ae") {
+    hideElement(paste0("wisExplanation", dash_suffix))
+    hideElement(paste0("sharpnessExplanation", dash_suffix))
+    showElement(paste0("aeExplanation", dash_suffix))
+    hideElement(paste0("coverageExplanation", dash_suffix))
+  }
+  if (scoreType == "coverage") {
+    hideElement(paste0("wisExplanation", dash_suffix))
+    hideElement(paste0("sharpnessExplanation", dash_suffix))
+    hideElement(paste0("aeExplanation", dash_suffix))
+    showElement(paste0("coverageExplanation", dash_suffix))
+  }
+}
+
 # All data is fully loaded from AWS
 DATA_LOADED <- FALSE
 loadData <- createDataLoader()
@@ -656,6 +683,7 @@ server <- function(input, output, session) {
         )
         DASH_SUFFIX <<- ""
         updateTargetChoices(session, choices)
+        showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
       } else if (input$tabset == "evaluations_archive") {
         choices <- list(
           "Incident Deaths" = "Deaths",
@@ -663,6 +691,7 @@ server <- function(input, output, session) {
         )
         DASH_SUFFIX <<- "_archive"
         updateTargetChoices(session, choices)
+        showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
       }
     },
     ignoreInit = TRUE
@@ -746,30 +775,7 @@ server <- function(input, output, session) {
       updateAsOfData()
     }
 
-    if (input$scoreType == "wis") {
-      showElement(paste0("wisExplanation", DASH_SUFFIX))
-      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-      hideElement(paste0("aeExplanation", DASH_SUFFIX))
-      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-    }
-    if (input$scoreType == "sharpness") {
-      showElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-      hideElement(paste0("wisExplanation", DASH_SUFFIX))
-      hideElement(paste0("aeExplanation", DASH_SUFFIX))
-      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-    }
-    if (input$scoreType == "ae") {
-      hideElement(paste0("wisExplanation", DASH_SUFFIX))
-      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-      showElement(paste0("aeExplanation", DASH_SUFFIX))
-      hideElement(paste0("coverageExplanation", DASH_SUFFIX))
-    }
-    if (input$scoreType == "coverage") {
-      hideElement(paste0("wisExplanation", DASH_SUFFIX))
-      hideElement(paste0("sharpnessExplanation", DASH_SUFFIX))
-      hideElement(paste0("aeExplanation", DASH_SUFFIX))
-      showElement(paste0("coverageExplanation", DASH_SUFFIX))
-    }
+    showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
     USE_CURR_TRUTH <<- TRUE
   })
 

--- a/app/server.R
+++ b/app/server.R
@@ -682,12 +682,12 @@ server <- function(input, output, session) {
           "Hospital Admissions" = "Hospitalizations"
         )
         DASH_SUFFIX <<- ""
-      } else if (input$tabset == "evaluations_archive") {
+      } else if (input$tabset == paste0("evaluations", ARCHIVE_TAB_SUFFIX)) {
         choices <- list(
           "Incident Deaths" = "Deaths",
           "Incident Cases" = "Cases"
         )
-        DASH_SUFFIX <<- "_archive"
+        DASH_SUFFIX <<- ARCHIVE_TAB_SUFFIX
       } else {
         return()
       }

--- a/app/server.R
+++ b/app/server.R
@@ -682,17 +682,17 @@ server <- function(input, output, session) {
           "Hospital Admissions" = "Hospitalizations"
         )
         DASH_SUFFIX <<- ""
-        updateTargetChoices(session, choices)
-        showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
       } else if (input$tabset == "evaluations_archive") {
         choices <- list(
           "Incident Deaths" = "Deaths",
           "Incident Cases" = "Cases"
         )
         DASH_SUFFIX <<- "_archive"
-        updateTargetChoices(session, choices)
-        showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
+      } else {
+        return()
       }
+      updateTargetChoices(session, choices)
+      showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
     },
     ignoreInit = TRUE
   )

--- a/app/ui.R
+++ b/app/ui.R
@@ -177,7 +177,7 @@ main <- tabsetPanel(
     )),
   ),
   create_output_panel("Evaluation Plots", ""),
-  create_output_panel("Archive Evaluation Plots", "_archive")
+  create_output_panel("Archive Evaluation Plots", ARCHIVE_TAB_SUFFIX)
 )
 
 ui <- delphiLayoutUI(


### PR DESCRIPTION
### Description
- In https://github.com/cmu-delphi/forecast-eval/pull/253, the score explanation doesn't show up when switching from the "current" to the "archive" tab. It only shows up on the archive tab when switching between score types. Explicitly ask for score explanation to be shown when tab is changed.
- Factor out score explanation display logic.
- Move the archive tab suffix to a global var.