### PR TITLE
Make dashboard selection options on load match hosp target variable

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -892,8 +892,10 @@ server <- function(input, output, session) {
 
   updateAsOfChoices <- function(session, truthDf) {
     asOfChoices <- truthDf %>%
-      select(Week_End_Date) %>%
-      filter(Week_End_Date <= CURRENT_WEEK_END_DATE()) %>%
+      # To prevent grouping columns from being added back on.
+      ungroup() %>%
+      distinct(Week_End_Date) %>%
+      filter(Week_End_Date <= CURRENT_WEEK_END_DATE(), !is.na(Week_End_Date)) %>%
       pull()
     selectedAsOf <- isolate(input$asOf)
     if (input$targetVariable == "Hospitalizations") {
@@ -910,9 +912,9 @@ server <- function(input, output, session) {
     # Make sure we have a valid as of selection
     nonValidAsOf <- selectedAsOf == "" || !(as.Date(selectedAsOf) %in% asOfChoices)
     if (length(asOfChoices) != 0 && nonValidAsOf) {
-      selectedAsOf <- max(asOfChoices, na.rm = TRUE)
+      selectedAsOf <- max(asOfChoices)
     }
-    AS_OF_CHOICES(sort(unique(asOfChoices)))
+    AS_OF_CHOICES(sort(asOfChoices))
     updateSelectInput(session, "asOf",
       choices = sort(asOfChoices),
       selected = selectedAsOf

--- a/app/server.R
+++ b/app/server.R
@@ -110,7 +110,9 @@ server <- function(input, output, session) {
   DASH_SUFFIX <- ""
   COLOR_SEED <- reactiveVal(171)
 
-  CURRENT_WEEK_END_DATE <- reactiveVal(CASES_DEATHS_CURRENT)
+  CURRENT_WEEK_END_DATE <- reactiveVal(
+    ifelse(INIT_TARGET == "Hospitalizations", HOSP_CURRENT, CASES_DEATHS_CURRENT)
+  )
 
   # Get scores
   loaded <- loadData(INIT_TARGET)

--- a/app/ui.R
+++ b/app/ui.R
@@ -98,9 +98,24 @@ sidebar <- tags$div(
     ),
     checkboxGroupInput(
       "aheads",
-      "Forecast Horizon (Weeks)",
-      choices = AHEAD_OPTIONS,
-      selected = AHEAD_OPTIONS[1],
+      switch(
+        INIT_TARGET,
+        "Hospitalizations" = "Forecast Horizon (Days)",
+        "Deaths" = "Forecast Horizon (Weeks)",
+        "Cases" = "Forecast Horizon (Weeks)"
+      ),
+      choices = switch(
+        INIT_TARGET,
+        "Hospitalizations" = HOSPITALIZATIONS_AHEAD_OPTIONS,
+        "Deaths" = AHEAD_OPTIONS,
+        "Cases" = AHEAD_OPTIONS
+      ),
+      selected = switch(
+        INIT_TARGET,
+        "Hospitalizations" = HOSPITALIZATIONS_AHEAD_OPTIONS[1L],
+        "Deaths" = AHEAD_OPTIONS[1L],
+        "Cases" = AHEAD_OPTIONS[1L]
+      ),
       inline = TRUE
     ),
     hidden(tags$p(

--- a/app/ui.R
+++ b/app/ui.R
@@ -98,24 +98,9 @@ sidebar <- tags$div(
     ),
     checkboxGroupInput(
       "aheads",
-      switch(
-        INIT_TARGET,
-        "Hospitalizations" = "Forecast Horizon (Days)",
-        "Deaths" = "Forecast Horizon (Weeks)",
-        "Cases" = "Forecast Horizon (Weeks)"
-      ),
-      choices = switch(
-        INIT_TARGET,
-        "Hospitalizations" = HOSPITALIZATIONS_AHEAD_OPTIONS,
-        "Deaths" = AHEAD_OPTIONS,
-        "Cases" = AHEAD_OPTIONS
-      ),
-      selected = switch(
-        INIT_TARGET,
-        "Hospitalizations" = HOSPITALIZATIONS_AHEAD_OPTIONS[1L],
-        "Deaths" = AHEAD_OPTIONS[1L],
-        "Cases" = AHEAD_OPTIONS[1L]
-      ),
+      "Forecast Horizon (Days)",
+      choices = HOSPITALIZATIONS_AHEAD_OPTIONS,
+      selected = HOSPITALIZATIONS_AHEAD_OPTIONS[1L],
       inline = TRUE
     ),
     hidden(tags$p(


### PR DESCRIPTION
### Description
The dashboard is showing an initial as-of date and forecast horizon selection that are not applicable to hospitalizations. Change the starting values to be valid. Also modify `updateAsOfChoices` logic to do more filtering/list size reduction at the beginning.

### Changes
- `CURRENT_WEEK_END_DATE` varies by target variable, and is always added on as the most recent (and by default, currently selected) as-of date. Since the old `CURRENT_WEEK_END_DATE` was set for cases and deaths, the default as-of selection was invalid for hospitalizations.
- Same for start-up ahead options and ahead selection.