### PR TITLE
Reduce unnecessary replotting on dashboard startup and on target variable switching

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -30,7 +30,18 @@ HOSPITALIZATIONS_AHEAD_OPTIONS <- c(
   HOSPITALIZATIONS_OFFSET + 14, HOSPITALIZATIONS_OFFSET + 21
 )
 
+CURRENT_TAB_SUFFIX <- ""
 ARCHIVE_TAB_SUFFIX <- "_archive"
+
+
+TARGET_VARS_BY_TAB <- list()
+TARGET_VARS_BY_TAB[[paste0("evaluations", CURRENT_TAB_SUFFIX)]] <- list(
+  "Hospital Admissions" = "Hospitalizations"
+)
+TARGET_VARS_BY_TAB[[paste0("evaluations", ARCHIVE_TAB_SUFFIX)]] <- list(
+  "Incident Deaths" = "Deaths",
+  "Incident Cases" = "Cases"
+)
 
 # Set the "previous" target to be the same as the starting target variable
 PREV_TARGET <- INIT_TARGET

--- a/app/server.R
+++ b/app/server.R
@@ -741,7 +741,10 @@ server <- function(input, output, session) {
     if (updateAsOf) {
       updateAsOfData(fetchDate = currentFetch)
     }
-  })
+  },
+  # Make higher priority than other `observe`s since we need to have data loaded first.
+  priority = 1
+  )
 
   observeEvent(input$scoreType, {
     df <- df_list[[input$targetVariable]]

--- a/app/server.R
+++ b/app/server.R
@@ -687,14 +687,13 @@ server <- function(input, output, session) {
   observeEvent(input$tabset,
     {
       if (input$tabset == paste0("evaluations", CURRENT_TAB_SUFFIX)) {
-        suffix <- CURRENT_TAB_SUFFIX
+        DASH_SUFFIX <<- CURRENT_TAB_SUFFIX
       } else if (input$tabset == paste0("evaluations", ARCHIVE_TAB_SUFFIX)) {
-        suffix <- ARCHIVE_TAB_SUFFIX
+        DASH_SUFFIX <<- ARCHIVE_TAB_SUFFIX
       } else {
         return()
       }
-      choices <- TARGET_VARS_BY_TAB[[paste0("evaluations", suffix)]]
-      DASH_SUFFIX <<- suffix
+      choices <- TARGET_VARS_BY_TAB[[paste0("evaluations", DASH_SUFFIX)]]
       updateTargetChoices(session, choices)
       showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
     },

--- a/app/server.R
+++ b/app/server.R
@@ -131,7 +131,7 @@ server <- function(input, output, session) {
   HOSP_CURRENT <- resolveCurrentHospDay()
 
   PREV_AS_OF_DATA <- reactiveVal(NULL)
-  AS_OF_CHOICES <- reactiveVal(NULL)
+  AS_OF_CHOICES <- reactiveVal(resolveCurrentHospDay())
   SUMMARIZING_OVER_ALL_LOCATIONS <- reactive(input$scoreType == "coverage" || input$location == TOTAL_LOCATIONS)
 
   DASH_SUFFIX <- ""
@@ -294,7 +294,7 @@ server <- function(input, output, session) {
     # Render truth plot with observed values
     truthDf <- filteredScoreDf
     ## this first condition is necessary when loading the dash
-    if (input$asOf == "") {
+    if (input$asOf == "" || !exists("TRUTH_PLOT")) {
       TRUTH_PLOT <<- truthPlot(truthDf, locationsIntersect, !is.null(asOfData), dfWithForecasts, colorPalette)
       output[[paste0("truthPlot", DASH_SUFFIX)]] <- renderPlotly({
         TRUTH_PLOT

--- a/app/server.R
+++ b/app/server.R
@@ -131,8 +131,24 @@ server <- function(input, output, session) {
   HOSP_CURRENT <- resolveCurrentHospDay()
 
   PREV_AS_OF_DATA <- reactiveVal(NULL)
-  AS_OF_CHOICES <- reactiveVal(resolveCurrentHospDay())
+  AS_OF_CHOICES <- reactiveVal(HOSP_CURRENT)
   SUMMARIZING_OVER_ALL_LOCATIONS <- reactive(input$scoreType == "coverage" || input$location == TOTAL_LOCATIONS)
+
+  # Set asof selection on startup to avoid creating initial plot multiple
+  # times. If asof selection is empty, the initial plot is created twice,
+  # once on startup and once when the as-of date is set later.
+  observeEvent(input$asOf,
+    {
+      if (input$asOf == "")
+      {
+        updateSelectInput(session, "asOf",
+          choices = AS_OF_CHOICES(),
+          selected = HOSP_CURRENT
+        )
+      }
+    },
+    once = TRUE
+  )
 
   DASH_SUFFIX <- ""
   COLOR_SEED <- reactiveVal(171)

--- a/app/server.R
+++ b/app/server.R
@@ -138,7 +138,7 @@ server <- function(input, output, session) {
   COLOR_SEED <- reactiveVal(171)
 
   CURRENT_WEEK_END_DATE <- reactiveVal(
-    ifelse(INIT_TARGET == "Hospitalizations", HOSP_CURRENT, CASES_DEATHS_CURRENT)
+    if_else(INIT_TARGET == "Hospitalizations", HOSP_CURRENT, CASES_DEATHS_CURRENT)
   )
 
   # Get scores

--- a/app/server.R
+++ b/app/server.R
@@ -922,7 +922,7 @@ server <- function(input, output, session) {
     }
     AS_OF_CHOICES(sort(asOfChoices))
     updateSelectInput(session, "asOf",
-      choices = sort(asOfChoices),
+      choices = AS_OF_CHOICES(),
       selected = selectedAsOf
     )
   }

--- a/app/server.R
+++ b/app/server.R
@@ -139,8 +139,7 @@ server <- function(input, output, session) {
   # once on startup and once when the as-of date is set later.
   observeEvent(input$asOf,
     {
-      if (input$asOf == "")
-      {
+      if (input$asOf == "") {
         updateSelectInput(session, "asOf",
           choices = AS_OF_CHOICES(),
           selected = HOSP_CURRENT

--- a/app/server.R
+++ b/app/server.R
@@ -154,6 +154,9 @@ server <- function(input, output, session) {
     if (input$location == "") {
       return()
     }
+    if (!(input$targetVariable %in% TARGET_VARS_BY_TAB[[isolate(input$tabset)]])) {
+      return()
+    }
 
     ## Setting target signal to be compared with asOfData
     if (input$targetVariable == "Cases") {
@@ -667,20 +670,15 @@ server <- function(input, output, session) {
 
   observeEvent(input$tabset,
     {
-      if (input$tabset == "evaluations") {
-        choices <- list(
-          "Hospital Admissions" = "Hospitalizations"
-        )
-        DASH_SUFFIX <<- ""
+      if (input$tabset == paste0("evaluations", CURRENT_TAB_SUFFIX)) {
+        suffix <- CURRENT_TAB_SUFFIX
       } else if (input$tabset == paste0("evaluations", ARCHIVE_TAB_SUFFIX)) {
-        choices <- list(
-          "Incident Deaths" = "Deaths",
-          "Incident Cases" = "Cases"
-        )
-        DASH_SUFFIX <<- ARCHIVE_TAB_SUFFIX
+        suffix <- ARCHIVE_TAB_SUFFIX
       } else {
         return()
       }
+      choices <- TARGET_VARS_BY_TAB[[paste0("evaluations", suffix)]]
+      DASH_SUFFIX <<- suffix
       updateTargetChoices(session, choices)
       showScoreExplanation(session, input$scoreType, DASH_SUFFIX)
     },

--- a/app/ui.R
+++ b/app/ui.R
@@ -131,9 +131,9 @@ sidebar <- tags$div(
     selectInput(
       "asOf",
       "As Of",
-      choices = "",
+      choices = resolveCurrentHospDay(),
       multiple = FALSE,
-      selected = ""
+      selected = resolveCurrentHospDay()
     ),
     tags$p(id = "missing-data-disclaimer", "Some locations may not have 'as of' data for the chosen 'as of' date"),
     div(

--- a/app/ui.R
+++ b/app/ui.R
@@ -129,9 +129,9 @@ sidebar <- tags$div(
     selectInput(
       "asOf",
       "As Of",
-      choices = resolveCurrentHospDay(),
+      choices = "",
       multiple = FALSE,
-      selected = resolveCurrentHospDay()
+      selected = ""
     ),
     tags$p(id = "missing-data-disclaimer", "Some locations may not have 'as of' data for the chosen 'as of' date"),
     div(

--- a/app/ui.R
+++ b/app/ui.R
@@ -59,9 +59,7 @@ sidebar <- tags$div(
     # NB conditions are written in JavaScript!!
     condition = "input.tabset.startsWith('evaluations')",
     radioButtons("targetVariable", "Target Variable",
-      choices = list(
-        "Hospital Admissions" = "Hospitalizations"
-      )
+      choices = TARGET_VARS_BY_TAB[[paste0("evaluations", CURRENT_TAB_SUFFIX)]]
     ),
     radioButtons("scoreType", "Scoring Metric",
       choices = list(


### PR DESCRIPTION
- Set initial as-of date for hospitalizations to avoid as of-finding loop/replot.
- Factor out lists of allowed tabs x target variables for brevity. Use tab name to index into list to avoid plotting when selected target variable shouldn't be displayed on that tab (i.e. first attempted plot when user switches tabs).
- Resolve issue where first "current" tab instance doesn't correctly show as-of truth data due to `ifelse` coercing dates into numerics; use `dplyr::if_else` instead.