### PR TITLE
Simplify `dplyr` use in dashboard `filter` logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
  stringr,
  markdown,
  memoise,
- purrr
+ purrr,
+ data.table
 Suggests:
  styler,
  lintr,

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -128,7 +128,7 @@ createS3DataLoader <- function() {
       s3Contents <<- newS3Contents
     }
     if (s3BucketHasChanged ||
-      !(targetVariable %in% names(df_list)) ||
+      !(targetVariable %chin% names(df_list)) ||
       nrow(df_list[[targetVariable]]) == 0) {
       df_list[[targetVariable]] <<- getAllData(s3DataFetcher, targetVariable)
       dataCreationDate <<- getCreationDate(s3DataFetcher)

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -56,7 +56,7 @@ filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FAL
 # Only use weekly aheads for hospitalizations
 # May change in the future
 filterHospitalizationsAheads <- function(scoreDf) {
-  scoreDf["weekday"] <- format(as.Date(scoreDf$target_end_date, '%Y-%m-%d'), "%A")
+  scoreDf["weekday"] <- format(as.Date(scoreDf$target_end_date, "%Y-%m-%d"), "%A")
   scoreDf <- filter(scoreDf, weekday == HOSPITALIZATIONS_TARGET_DAY)
   scoreDf$ahead_group <- case_when(
     scoreDf$ahead >= HOSPITALIZATIONS_OFFSET & scoreDf$ahead < 7 + HOSPITALIZATIONS_OFFSET ~ 1L,

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -56,7 +56,8 @@ filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FAL
 # Only use weekly aheads for hospitalizations
 # May change in the future
 filterHospitalizationsAheads <- function(scoreDf) {
-  scoreDf["weekday"] <- format(as.Date(scoreDf$target_end_date, "%Y-%m-%d"), "%A")
+  days_list <- c("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+  scoreDf["weekday"] <- days_list[data.table::wday(as.Date(scoreDf$target_end_date, "%Y-%m-%d"))]
   scoreDf <- filter(scoreDf, weekday == HOSPITALIZATIONS_TARGET_DAY)
   scoreDf$ahead_group <- case_when(
     scoreDf$ahead >= HOSPITALIZATIONS_OFFSET & scoreDf$ahead < 7 + HOSPITALIZATIONS_OFFSET ~ 1L,

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -25,7 +25,7 @@ filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FAL
   locationList <- lapply(locationList, function(x) x[x != "us"])
   # Get the intersection of all the locations in these lists
   locationsIntersect <- unique(Reduce(intersect, locationList))
-  filteredScoreDf <- filter(filteredScoreDf, geo_value %in% locationsIntersect)
+  filteredScoreDf <- filter(filteredScoreDf, geo_value %chin% locationsIntersect)
   if (scoreType == "coverage") {
     if (hasAsOfData) {
       filteredScoreDf <- filteredScoreDf %>%

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -14,18 +14,18 @@ renameScoreCol <- function(filteredScoreDf, scoreType, coverageInterval) {
 
 filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FALSE, filterDate) {
   locationsIntersect <- list()
-  filteredScoreDf <- filteredScoreDf %>% filter(!is.na(Score) | target_end_date >= filterDate)
+  filteredScoreDf <- filter(filteredScoreDf, !is.na(Score) | target_end_date >= filterDate)
   # Create df with col for all locations across each unique date, ahead and forecaster combo
   locationDf <- filteredScoreDf %>%
     group_by(forecaster, target_end_date, ahead) %>%
     summarize(location_list = paste(sort(unique(geo_value)), collapse = ","))
-  locationDf <- locationDf %>% filter(location_list != c("us"))
+  locationDf <- filter(locationDf, location_list != c("us"))
   # Create a list containing each row's location list
   locationList <- sapply(locationDf$location_list, function(x) strsplit(x, ","))
   locationList <- lapply(locationList, function(x) x[x != "us"])
   # Get the intersection of all the locations in these lists
   locationsIntersect <- unique(Reduce(intersect, locationList))
-  filteredScoreDf <- filteredScoreDf %>% filter(geo_value %in% locationsIntersect)
+  filteredScoreDf <- filter(filteredScoreDf, geo_value %in% locationsIntersect)
   if (scoreType == "coverage") {
     if (hasAsOfData) {
       filteredScoreDf <- filteredScoreDf %>%
@@ -57,7 +57,7 @@ filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FAL
 # May change in the future
 filterHospitalizationsAheads <- function(scoreDf) {
   scoreDf["weekday"] <- weekdays(as.Date(scoreDf$target_end_date))
-  scoreDf <- scoreDf %>% filter(weekday == HOSPITALIZATIONS_TARGET_DAY)
+  scoreDf <- filter(scoreDf, weekday == HOSPITALIZATIONS_TARGET_DAY)
 
   oneAheadDf <- scoreDf %>%
     filter(ahead >= HOSPITALIZATIONS_OFFSET) %>%
@@ -68,26 +68,34 @@ filterHospitalizationsAheads <- function(scoreDf) {
 
   return(bind_rows(
     scoreDf %>%
-      filter(ahead >= HOSPITALIZATIONS_OFFSET) %>%
-      filter(ahead < 7 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(
+        ahead >= HOSPITALIZATIONS_OFFSET,
+        ahead < 7 + HOSPITALIZATIONS_OFFSET
+      ) %>%
       group_by(target_end_date, forecaster) %>%
       filter(ahead == min(ahead)) %>%
       mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[1]),
     scoreDf %>%
-      filter(ahead >= 7 + HOSPITALIZATIONS_OFFSET) %>%
-      filter(ahead < 14 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(
+        ahead >= 7 + HOSPITALIZATIONS_OFFSET,
+        ahead < 14 + HOSPITALIZATIONS_OFFSET
+      ) %>%
       group_by(target_end_date, forecaster) %>%
       filter(ahead == min(ahead)) %>%
       mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[2]),
     scoreDf %>%
-      filter(ahead >= 14 + HOSPITALIZATIONS_OFFSET) %>%
-      filter(ahead < 21 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(
+        ahead >= 14 + HOSPITALIZATIONS_OFFSET,
+        ahead < 21 + HOSPITALIZATIONS_OFFSET
+      ) %>%
       group_by(target_end_date, forecaster) %>%
       filter(ahead == min(ahead)) %>%
       mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[3]),
     scoreDf %>%
-      filter(ahead >= 21 + HOSPITALIZATIONS_OFFSET) %>%
-      filter(ahead < 28 + HOSPITALIZATIONS_OFFSET) %>%
+      filter(
+        ahead >= 21 + HOSPITALIZATIONS_OFFSET,
+        ahead < 28 + HOSPITALIZATIONS_OFFSET
+      ) %>%
       group_by(target_end_date, forecaster) %>%
       filter(ahead == min(ahead)) %>%
       mutate(ahead = HOSPITALIZATIONS_AHEAD_OPTIONS[4])

--- a/app/R/data_manipulation.R
+++ b/app/R/data_manipulation.R
@@ -57,6 +57,7 @@ filterOverAllLocations <- function(filteredScoreDf, scoreType, hasAsOfData = FAL
 # May change in the future
 filterHospitalizationsAheads <- function(scoreDf) {
   days_list <- c("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+  # Make sure to use `data.table`'s `wday`; `lubridate` has a function of the same name.
   scoreDf["weekday"] <- days_list[data.table::wday(as.Date(scoreDf$target_end_date, "%Y-%m-%d"))]
   scoreDf <- filter(scoreDf, weekday == HOSPITALIZATIONS_TARGET_DAY)
   scoreDf$ahead_group <- case_when(

--- a/app/R/exportScores.R
+++ b/app/R/exportScores.R
@@ -8,7 +8,7 @@ exportScoresUI <- function(id = "exportScores") {
 createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, forecasters, loc, coverageInterval) {
   scoreDf <- filter(
     scoreDf[[targetVariable]],
-    forecaster %in% forecasters
+    forecaster %chin% forecasters
   )
   scoreDf <- renameScoreCol(scoreDf, scoreType, coverageInterval)
 

--- a/app/R/exportScores.R
+++ b/app/R/exportScores.R
@@ -19,7 +19,7 @@ createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, fore
     scoreDf <- filterOverAllLocations(scoreDf, scoreType)
     return(scoreDf[[1]])
   } else {
-    scoreDf <- scoreDf %>% filter(geo_value == tolower(loc))
+    scoreDf <- filter(scoreDf, geo_value == tolower(loc))
     scoreDf <- scoreDf[c(
       "ahead", "geo_value", "forecaster", "forecast_date",
       "data_source", "target_end_date", "Score", "actual"

--- a/app/global.R
+++ b/app/global.R
@@ -8,6 +8,7 @@ library(lubridate)
 library(viridis)
 library(tsibble)
 library(covidcast)
+library(data.table)
 
 appVersion <- "6.1.0"
 
@@ -35,10 +36,10 @@ ARCHIVE_TAB_SUFFIX <- "_archive"
 
 
 TARGET_VARS_BY_TAB <- list()
-TARGET_VARS_BY_TAB[[paste0("evaluations", CURRENT_TAB_SUFFIX)]] <- list(
+TARGET_VARS_BY_TAB[[paste0("evaluations", CURRENT_TAB_SUFFIX)]] <- c(
   "Hospital Admissions" = "Hospitalizations"
 )
-TARGET_VARS_BY_TAB[[paste0("evaluations", ARCHIVE_TAB_SUFFIX)]] <- list(
+TARGET_VARS_BY_TAB[[paste0("evaluations", ARCHIVE_TAB_SUFFIX)]] <- c(
   "Incident Deaths" = "Deaths",
   "Incident Cases" = "Cases"
 )

--- a/app/server.R
+++ b/app/server.R
@@ -946,7 +946,7 @@ server <- function(input, output, session) {
     }
     asOfChoices <- c(asOfChoices, CURRENT_WEEK_END_DATE())
     # Make sure we have a valid as of selection
-    nonValidAsOf <- selectedAsOf == "" || !(as.Date(selectedAsOf) %in% asOfChoices)
+    nonValidAsOf <- selectedAsOf == "" || !(selectedAsOf %in% asOfChoices)
     if (length(asOfChoices) != 0 && nonValidAsOf) {
       selectedAsOf <- max(asOfChoices)
     }

--- a/app/server.R
+++ b/app/server.R
@@ -202,6 +202,10 @@ server <- function(input, output, session) {
       input$asOf != "" &&
       nrow(PREV_AS_OF_DATA()) != 0 &&
       input$asOf < CURRENT_WEEK_END_DATE()) {
+      # Equivalent to but faster than the `dplyr`:
+      #  asOfData <- PREV_AS_OF_DATA() %>%
+      #    rename(target_end_date = time_value, as_of_actual = value) %>%
+      #    select(target_end_date, geo_value, as_of_actual)
       asOfData <- PREV_AS_OF_DATA()
       asOfData$target_end_date <- asOfData$time_value
       asOfData$as_of_actual <- asOfData$value

--- a/app/server.R
+++ b/app/server.R
@@ -931,8 +931,8 @@ server <- function(input, output, session) {
       # To prevent grouping columns from being added back on.
       ungroup() %>%
       distinct(Week_End_Date) %>%
-      filter(Week_End_Date <= CURRENT_WEEK_END_DATE(), !is.na(Week_End_Date)) %>%
-      pull()
+      filter(Week_End_Date < CURRENT_WEEK_END_DATE(), !is.na(Week_End_Date)) %>%
+      pull(Week_End_Date)
     selectedAsOf <- isolate(input$asOf)
     if (input$targetVariable == "Hospitalizations") {
       minChoice <- MIN_AVAIL_HOSP_AS_OF_DATE
@@ -946,7 +946,7 @@ server <- function(input, output, session) {
     }
     asOfChoices <- c(asOfChoices, CURRENT_WEEK_END_DATE())
     # Make sure we have a valid as of selection
-    nonValidAsOf <- selectedAsOf == "" || !(selectedAsOf %in% asOfChoices)
+    nonValidAsOf <- selectedAsOf == "" || !(as.Date(selectedAsOf) %in% asOfChoices)
     if (length(asOfChoices) != 0 && nonValidAsOf) {
       selectedAsOf <- max(asOfChoices)
     }

--- a/app/server.R
+++ b/app/server.R
@@ -8,8 +8,7 @@ updateTargetChoices <- function(session, targetChoices) {
 updateForecasterChoices <- function(session, df, forecasterInput, scoreType) {
   if (scoreType == "wis") {
     df <- filter(df, !is.na(wis))
-  }
-  if (scoreType == "ae") {
+  } else if (scoreType == "ae") {
     df <- filter(df, !is.na(ae))
   }
   forecasterChoices <- distinct(df, forecaster) %>% pull()
@@ -344,20 +343,28 @@ server <- function(input, output, session) {
     updateAsOfChoices(session, truthDf)
 
     # Format and transform data for plot
-    filteredScoreDf <- filter(filteredScoreDf, !is.na(Week_End_Date))
-    filteredScoreDf <- mutate(
+    filteredScoreDf <- filter(
       filteredScoreDf[, c("Forecaster", "Forecast_Date", "Week_End_Date", "Score", "ahead")],
-      across(where(is.numeric), ~ round(., 2))
+      !is.na(Week_End_Date)
     )
+    filteredScoreDf$Score <- round(filteredScoreDf$Score, 2)
+
     if (input$scoreType != "coverage") {
       if (input$scaleByBaseline) {
-        baselineDf <- filter(filteredScoreDf, Forecaster %in% "COVIDhub-baseline")
-        filteredScoreDf <- merge(filteredScoreDf, baselineDf, by = c("Week_End_Date", "ahead"))
+        baselineDf <- filter(
+          filteredScoreDf,
+          Forecaster == "COVIDhub-baseline"
+        )[, c("Week_End_Date", "ahead", "Score")]
+        baselineDf$Score_baseline <- baselineDf$Score
+        baselineDf$Score <- NULL
 
+        # Add on reference scores from baseline forecaster
+        filteredScoreDf <- merge(
+          filteredScoreDf, baselineDf,
+          by = c("Week_End_Date", "ahead"), suffixes=c(), sort=FALSE
+        )
         # Scale score by baseline forecaster
-        filteredScoreDf$Score <- filteredScoreDf$Score.x / filteredScoreDf$Score.y
-        filteredScoreDf$Forecaster <- filteredScoreDf$Forecaster.x
-        filteredScoreDf$Forecast_Date <- filteredScoreDf$Forecast_Date.x
+        filteredScoreDf$Score <- filteredScoreDf$Score / filteredScoreDf$Score_baseline
         filteredScoreDf <- filteredScoreDf[, c("Forecaster", "Forecast_Date", "Week_End_Date", "ahead", "Score")]
       }
       if (input$logScale) {
@@ -630,7 +637,7 @@ server <- function(input, output, session) {
 
     if (hasAsOfData) {
       # We want the forecasts to be later than latest as of date with data
-      lastEndDate <- tail(filter(filteredDf, !is.na(Reported_As_Of_Incidence)), n = 1)$Week_End_Date[1]
+      lastEndDate <- tail(filter(filteredDf, !is.na(Reported_As_Of_Incidence))[["Week_End_Date"]], n = 1)
       dfWithForecasts <- dfWithForecasts %>%
         filter(forecast_date >= lastEndDate) %>%
         group_by(Week_End_Date) %>%
@@ -674,11 +681,13 @@ server <- function(input, output, session) {
     if (hasAsOfData) {
       keepCols <- c(keepCols, "Reported_As_Of_Incidence")
     }
-    filteredDf <- merge(filteredDf, dfWithForecasts, by = c("Week_End_Date", "Forecaster"), all = TRUE) %>%
-      group_by(Week_End_Date)
-    # Remove rows of NAs
-    filteredDf <- filter(filteredDf[, keepCols], !is.null(Forecaster))
-    filteredDf <- filteredDf %>%
+    filteredDf <- merge(
+        filteredDf, dfWithForecasts,
+        by = c("Week_End_Date", "Forecaster"), all = TRUE, sort = FALSE
+      )[, keepCols] %>%
+      group_by(Week_End_Date) %>%
+      # Remove rows of NAs
+      filter(!is.null(Forecaster)) %>%
       arrange(Week_End_Date) %>%
       fill(Reported_Incidence, .direction = "downup")
     return(filteredDf)

--- a/app/server.R
+++ b/app/server.R
@@ -7,10 +7,10 @@ updateTargetChoices <- function(session, targetChoices) {
 
 updateForecasterChoices <- function(session, df, forecasterInput, scoreType) {
   if (scoreType == "wis") {
-    df <- df %>% filter(!is.na(wis))
+    df <- filter(df, !is.na(wis))
   }
   if (scoreType == "ae") {
-    df <- df %>% filter(!is.na(ae))
+    df <- filter(df, !is.na(ae))
   }
   forecasterChoices <- distinct(df, forecaster) %>% pull()
   updateSelectInput(session, "forecasters",
@@ -20,7 +20,7 @@ updateForecasterChoices <- function(session, df, forecasterInput, scoreType) {
 }
 
 updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices, coverageInput, output) {
-  df <- df %>% filter(forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %in% forecasterChoices)
   df <- Filter(function(x) !all(is.na(x)), df)
   coverageChoices <- intersect(colnames(df), COVERAGE_INTERVALS)
   # Ensure previously selected options are still allowed
@@ -38,7 +38,7 @@ updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices
 }
 
 updateLocationChoices <- function(session, df, targetVariable, forecasterChoices, locationInput) {
-  df <- df %>% filter(forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %in% forecasterChoices)
   locationChoices <- distinct(df, geo_value) %>%
     pull() %>%
     toupper()
@@ -66,7 +66,7 @@ updateLocationChoices <- function(session, df, targetVariable, forecasterChoices
 }
 
 updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, aheads, targetVariableChange) {
-  df <- df %>% filter(forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %in% forecasterChoices)
   if (targetVariable == "Hospitalizations") {
     aheadOptions <- HOSPITALIZATIONS_AHEAD_OPTIONS
     title <- "Forecast Horizon (Days)"
@@ -188,7 +188,7 @@ server <- function(input, output, session) {
       dfWithForecasts <- filteredScoreDf
     }
     # Need to do this after setting dfWithForecasts to leave in aheads for forecasts
-    filteredScoreDf <- filteredScoreDf %>% filter(ahead %in% input$aheads)
+    filteredScoreDf <- filter(filteredScoreDf, ahead %in% input$aheads)
     if (nrow(filteredScoreDf) == 0) {
       output[[paste0("renderWarningText", DASH_SUFFIX)]] <- renderText(paste0(
         "The selected forecasters do not have enough data ",
@@ -203,14 +203,15 @@ server <- function(input, output, session) {
       input$asOf != "" &&
       nrow(PREV_AS_OF_DATA()) != 0 &&
       input$asOf < CURRENT_WEEK_END_DATE()) {
-      asOfData <- PREV_AS_OF_DATA() %>%
-        rename(target_end_date = time_value, as_of_actual = value) %>%
-        select(target_end_date, geo_value, as_of_actual)
+      asOfData <- PREV_AS_OF_DATA()
+      asOfData$target_end_date <- asOfData$time_value
+      asOfData$as_of_actual <- asOfData$value
+      asOfData <- asOfData[, c("target_end_date", "geo_value", "as_of_actual")]
     }
 
     if (!is.null(asOfData) && nrow(asOfData) != 0) {
       # Get the 'as of' dates that are the target_end_dates in the scoring df
-      dateGroupDf <- asOfData %>% filter(asOfData$target_end_date %in% filteredScoreDf$target_end_date)
+      dateGroupDf <- filter(asOfData, asOfData$target_end_date %in% filteredScoreDf$target_end_date)
       if (nrow(dateGroupDf) != 0) {
         # Since cases and deaths are shown as weekly incidence, but the "as of" data from the covidcast API
         # is daily, we need to sum over the days leading up to the target_end_date of each week to get the
@@ -231,7 +232,7 @@ server <- function(input, output, session) {
       filteredScoreDf <- filteredScoreDfAndIntersections[[1]]
       locationsIntersect <- filteredScoreDfAndIntersections[[2]]
       if (input$showForecasts) {
-        dfWithForecasts <- dfWithForecasts %>% filter(geo_value %in% locationsIntersect)
+        dfWithForecasts <- filter(dfWithForecasts, geo_value %in% locationsIntersect)
       }
       aggregateText <- "*For fair comparison, all displayed forecasters on all displayed dates are compared across a common set of states and territories."
       if (input$scoreType == "coverage") {
@@ -343,19 +344,21 @@ server <- function(input, output, session) {
     updateAsOfChoices(session, truthDf)
 
     # Format and transform data for plot
-    filteredScoreDf <- filteredScoreDf %>%
-      filter(!is.na(Week_End_Date)) %>%
-      select(Forecaster, Forecast_Date, Week_End_Date, Score, ahead) %>%
-      mutate(across(where(is.numeric), ~ round(., 2)))
+    filteredScoreDf <- filter(filteredScoreDf, !is.na(Week_End_Date))
+    filteredScoreDf <- mutate(
+      filteredScoreDf[, c("Forecaster", "Forecast_Date", "Week_End_Date", "Score", "ahead")],
+      across(where(is.numeric), ~ round(., 2))
+    )
     if (input$scoreType != "coverage") {
       if (input$scaleByBaseline) {
-        baselineDf <- filteredScoreDf %>% filter(Forecaster %in% "COVIDhub-baseline")
-        filteredScoreDfMerged <- merge(filteredScoreDf, baselineDf, by = c("Week_End_Date", "ahead"))
-        # Scaling score by baseline forecaster
-        filteredScoreDfMerged$Score.x <- filteredScoreDfMerged$Score.x / filteredScoreDfMerged$Score.y
-        filteredScoreDf <- filteredScoreDfMerged %>%
-          rename(Forecaster = Forecaster.x, Score = Score.x, Forecast_Date = Forecast_Date.x) %>%
-          select(Forecaster, Forecast_Date, Week_End_Date, ahead, Score)
+        baselineDf <- filter(filteredScoreDf, Forecaster %in% "COVIDhub-baseline")
+        filteredScoreDf <- merge(filteredScoreDf, baselineDf, by = c("Week_End_Date", "ahead"))
+
+        # Scale score by baseline forecaster
+        filteredScoreDf$Score <- filteredScoreDf$Score.x / filteredScoreDf$Score.y
+        filteredScoreDf$Forecaster <- filteredScoreDf$Forecaster.x
+        filteredScoreDf$Forecast_Date <- filteredScoreDf$Forecast_Date.x
+        filteredScoreDf <- filteredScoreDf[, c("Forecaster", "Forecast_Date", "Week_End_Date", "ahead", "Score")]
       }
       if (input$logScale) {
         filteredScoreDf$Score <- log10(filteredScoreDf$Score)
@@ -537,16 +540,18 @@ server <- function(input, output, session) {
     }
     if (input$scoreType == "wis" || input$scoreType == "sharpness") {
       # Only show WIS or Sharpness for forecasts that have all intervals or are for future dates
-      filteredScoreDf <- filteredScoreDf %>%
-        filter((
+      filteredScoreDf <- filter(
+        filteredScoreDf,
+        (
           !is.na(`50`) &
             !is.na(`80`) &
             !is.na(`95`)
-        ) |
-          target_end_date >= dataCreationDate)
+        ) | target_end_date >= dataCreationDate
+      )
       if (input$targetVariable == "Deaths") {
-        filteredScoreDf <- filteredScoreDf %>%
-          filter((
+        filteredScoreDf <- filter(
+          filteredScoreDf,
+          (
             !is.na(`10`) &
               !is.na(`20`) &
               !is.na(`30`) &
@@ -555,8 +560,8 @@ server <- function(input, output, session) {
               !is.na(`70`) &
               !is.na(`90`) &
               !is.na(`98`)
-          ) |
-            target_end_date >= dataCreationDate)
+          ) | target_end_date >= dataCreationDate
+        )
       }
     }
     filteredScoreDf <- renameScoreCol(filteredScoreDf, input$scoreType, input$coverageInterval)
@@ -574,9 +579,11 @@ server <- function(input, output, session) {
 
       # Cut off the extra days on beginning and end of series so that when we sum the values we are only
       # summing over the weeks included in the score plot
-      asOfData <- asOfData %>%
-        filter(target_end_date >= min(filteredScoreDf$target_end_date) - 6) %>%
-        filter(target_end_date <= isolate(input$asOf))
+      asOfData <- filter(
+        asOfData,
+        target_end_date >= min(filteredScoreDf$target_end_date) - 6,
+        target_end_date <= isolate(input$asOf)
+      )
 
       # Fill in the date_group column with the target week end days for all intervening days
       asOfData <- asOfData %>%
@@ -585,7 +592,7 @@ server <- function(input, output, session) {
 
       # In the case where there are target week end days missing from the scoring or as of data
       # we don't want to end up summing values over multiple weeks so we make sure each date_group only spans one week
-      asOfData <- asOfData %>% filter(asOfData$date_group - asOfData$target_end_date < 7)
+      asOfData <- filter(asOfData, asOfData$date_group - asOfData$target_end_date < 7)
 
       asOfData <- asOfData[c("geo_value", "as_of_actual", "date_group")]
       # Sum over preceding week for all weekly target variables
@@ -601,10 +608,10 @@ server <- function(input, output, session) {
       # This is taken care of above for cases and deaths.
       minDate <- min(filteredScoreDf$target_end_date)
       if (!SUMMARIZING_OVER_ALL_LOCATIONS()) {
-        chosenLocationDf <- filteredScoreDf %>% filter(geo_value == tolower(input$location))
+        chosenLocationDf <- filter(filteredScoreDf, geo_value == tolower(input$location))
         minDate <- min(chosenLocationDf$target_end_date)
       }
-      asOfData <- asOfData %>% filter(target_end_date >= minDate)
+      asOfData <- filter(asOfData, target_end_date >= minDate)
     }
     return(asOfData)
   }
@@ -613,7 +620,7 @@ server <- function(input, output, session) {
     dfWithForecasts <- dfWithForecasts %>%
       rename(Week_End_Date = target_end_date, Forecaster = forecaster, Quantile_50 = value_50)
     if (!SUMMARIZING_OVER_ALL_LOCATIONS()) {
-      dfWithForecasts <- dfWithForecasts %>% filter(geo_value == tolower(input$location))
+      dfWithForecasts <- filter(dfWithForecasts, geo_value == tolower(input$location))
     } else {
       # Sum the predictions for all included locations
       dfWithForecasts <- dfWithForecasts %>%
@@ -623,7 +630,7 @@ server <- function(input, output, session) {
 
     if (hasAsOfData) {
       # We want the forecasts to be later than latest as of date with data
-      lastEndDate <- tail(filteredDf %>% filter(!is.na(Reported_As_Of_Incidence)), n = 1)$Week_End_Date[1]
+      lastEndDate <- tail(filter(filteredDf, !is.na(Reported_As_Of_Incidence)), n = 1)$Week_End_Date[1]
       dfWithForecasts <- dfWithForecasts %>%
         filter(forecast_date >= lastEndDate) %>%
         group_by(Week_End_Date) %>%
@@ -649,8 +656,7 @@ server <- function(input, output, session) {
     # Take only those forecasts with a forecast date before the next as of date in dropdown
     # aka within the week after the current as of shown
     if (length(nextAsOfInList) != 0 && !is.na(nextAsOfInList)) {
-      dfWithForecasts <- dfWithForecasts %>%
-        filter(forecast_date < nextAsOfInList)
+      dfWithForecasts <- filter(dfWithForecasts, forecast_date < nextAsOfInList)
     }
 
     # Hospitalizations will have multiple forecast dates within this target week
@@ -664,15 +670,14 @@ server <- function(input, output, session) {
         filter(forecast_date == first(forecast_date))
     }
 
-    keepCols <- c("Quantile_50", "Forecaster", "Reported_Incidence")
+    keepCols <- c("Week_End_Date", "Quantile_50", "Forecaster", "Reported_Incidence")
     if (hasAsOfData) {
       keepCols <- c(keepCols, "Reported_As_Of_Incidence")
     }
     filteredDf <- merge(filteredDf, dfWithForecasts, by = c("Week_End_Date", "Forecaster"), all = TRUE) %>%
-      group_by(Week_End_Date) %>%
-      select(keepCols)
+      group_by(Week_End_Date)
     # Remove rows of NAs
-    filteredDf <- filteredDf %>% filter(!is.null(Forecaster))
+    filteredDf <- filter(filteredDf[, keepCols], !is.null(Forecaster))
     filteredDf <- filteredDf %>%
       arrange(Week_End_Date) %>%
       fill(Reported_Incidence, .direction = "downup")

--- a/app/server.R
+++ b/app/server.R
@@ -19,7 +19,7 @@ updateForecasterChoices <- function(session, df, forecasterInput, scoreType) {
 }
 
 updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices, coverageInput, output) {
-  df <- filter(df, forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %chin% forecasterChoices)
   df <- Filter(function(x) !all(is.na(x)), df)
   coverageChoices <- intersect(colnames(df), COVERAGE_INTERVALS)
   # Ensure previously selected options are still allowed
@@ -37,7 +37,7 @@ updateCoverageChoices <- function(session, df, targetVariable, forecasterChoices
 }
 
 updateLocationChoices <- function(session, df, targetVariable, forecasterChoices, locationInput) {
-  df <- filter(df, forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %chin% forecasterChoices)
   locationChoices <- distinct(df, geo_value) %>%
     pull() %>%
     toupper()
@@ -65,7 +65,7 @@ updateLocationChoices <- function(session, df, targetVariable, forecasterChoices
 }
 
 updateAheadChoices <- function(session, df, targetVariable, forecasterChoices, aheads, targetVariableChange) {
-  df <- filter(df, forecaster %in% forecasterChoices)
+  df <- filter(df, forecaster %chin% forecasterChoices)
   if (targetVariable == "Hospitalizations") {
     aheadOptions <- HOSPITALIZATIONS_AHEAD_OPTIONS
     title <- "Forecast Horizon (Days)"
@@ -168,7 +168,7 @@ server <- function(input, output, session) {
     if (input$location == "") {
       return()
     }
-    if (!(input$targetVariable %in% TARGET_VARS_BY_TAB[[isolate(input$tabset)]])) {
+    if (!(input$targetVariable %chin% TARGET_VARS_BY_TAB[[isolate(input$tabset)]])) {
       return()
     }
 
@@ -231,7 +231,7 @@ server <- function(input, output, session) {
       filteredScoreDf <- filteredScoreDfAndIntersections[[1]]
       locationsIntersect <- filteredScoreDfAndIntersections[[2]]
       if (input$showForecasts) {
-        dfWithForecasts <- filter(dfWithForecasts, geo_value %in% locationsIntersect)
+        dfWithForecasts <- filter(dfWithForecasts, geo_value %chin% locationsIntersect)
       }
       aggregateText <- "*For fair comparison, all displayed forecasters on all displayed dates are compared across a common set of states and territories."
       if (input$scoreType == "coverage") {
@@ -539,7 +539,7 @@ server <- function(input, output, session) {
   filterScoreDf <- function() {
     filteredScoreDf <- filter(
       df_list[[input$targetVariable]],
-      forecaster %in% input$forecasters
+      forecaster %chin% input$forecasters
     )
 
     if (input$targetVariable == "Hospitalizations") {
@@ -795,7 +795,7 @@ server <- function(input, output, session) {
   observeEvent(input$forecasters, {
     df <- filter(
       df_list[[input$targetVariable]],
-      forecaster %in% input$forecasters
+      forecaster %chin% input$forecasters
     )
 
     updateAheadChoices(session, df, input$targetVariable, input$forecasters, input$aheads, FALSE)

--- a/app/server.R
+++ b/app/server.R
@@ -361,7 +361,7 @@ server <- function(input, output, session) {
         # Add on reference scores from baseline forecaster
         filteredScoreDf <- merge(
           filteredScoreDf, baselineDf,
-          by = c("Week_End_Date", "ahead"), suffixes=c(), sort=FALSE
+          by = c("Week_End_Date", "ahead"), suffixes = c(), sort = FALSE
         )
         # Scale score by baseline forecaster
         filteredScoreDf$Score <- filteredScoreDf$Score / filteredScoreDf$Score_baseline
@@ -682,9 +682,9 @@ server <- function(input, output, session) {
       keepCols <- c(keepCols, "Reported_As_Of_Incidence")
     }
     filteredDf <- merge(
-        filteredDf, dfWithForecasts,
-        by = c("Week_End_Date", "Forecaster"), all = TRUE, sort = FALSE
-      )[, keepCols] %>%
+      filteredDf, dfWithForecasts,
+      by = c("Week_End_Date", "Forecaster"), all = TRUE, sort = FALSE
+    )[, keepCols] %>%
       group_by(Week_End_Date) %>%
       # Remove rows of NAs
       filter(!is.null(Forecaster)) %>%


### PR DESCRIPTION
- Make select `dplyr`-based processing steps simpler and faster
- Remove unnecessary pipes
- Use `data.table`'s character vector-optimized "in" operator, `%chin%`, in slow filter steps
- Use `data.table`'s `wday` function to get weekday name from dates