### PR TITLE
Move `PREV_TARGET` to session-specific global to not leak behavior between users

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -43,9 +43,6 @@ TARGET_VARS_BY_TAB[[paste0("evaluations", ARCHIVE_TAB_SUFFIX)]] <- list(
   "Incident Cases" = "Cases"
 )
 
-# Set the "previous" target to be the same as the starting target variable
-PREV_TARGET <- INIT_TARGET
-
 # When RE_RENDER_TRUTH = TRUE
 # summaryPlot will be called only to update TruthPlot
 RE_RENDER_TRUTH <- FALSE

--- a/app/server.R
+++ b/app/server.R
@@ -130,6 +130,9 @@ server <- function(input, output, session) {
   CASES_DEATHS_CURRENT <- resolveCurrentCasesDeathDay()
   HOSP_CURRENT <- resolveCurrentHospDay()
 
+  # Set the "previous" target to be the same as the starting target variable
+  PREV_TARGET <- INIT_TARGET
+
   PREV_AS_OF_DATA <- reactiveVal(NULL)
   AS_OF_CHOICES <- reactiveVal(HOSP_CURRENT)
   SUMMARIZING_OVER_ALL_LOCATIONS <- reactive(input$scoreType == "coverage" || input$location == TOTAL_LOCATIONS)


### PR DESCRIPTION
The `PREV_TARGET` variable was defined as a Shiny-wide global constant such that it could be shared between user sessions. However, each user session modifies `PREV_TARGET` out of its own environment with `<<-` which means the constant is changing for other users! Move `PREV_TARGET` to be defined in the beginning of the `server` function to keep it tied to a particular user session.