### PR TITLE
When changing score to/from coverage, show main plot and make sure truth data is relevant

### DIFF
--- a/app/global.R
+++ b/app/global.R
@@ -18,6 +18,7 @@ HOSPITALIZATIONS_TARGET_DAY <- "Wednesday"
 TOTAL_LOCATIONS <- "Totaled Over States*"
 AHEAD_OPTIONS <- c(1, 2, 3, 4)
 
+INIT_SCORE_TYPE <- "wis"
 INIT_TARGET <- "Hospitalizations"
 TARGET_OPTIONS <- c("Deaths", "Cases", "Hospitalizations")
 

--- a/app/ui.R
+++ b/app/ui.R
@@ -67,7 +67,8 @@ sidebar <- tags$div(
         "Spread" = "sharpness",
         "Absolute Error" = "ae",
         "Coverage" = "coverage"
-      )
+      ),
+      selected = INIT_SCORE_TYPE
     ),
     conditionalPanel(
       condition = "input.scoreType != 'coverage'",


### PR DESCRIPTION
### Description
1. The default behavior in the [`input$scoreType` `observer`](https://github.com/cmu-delphi/forecast-eval/blob/49896afaece66985f0b0d59c3eab1dee20bfe32a/app/server.R#L785) is to [reuse the existing truth plot](https://github.com/cmu-delphi/forecast-eval/blob/49896afaece66985f0b0d59c3eab1dee20bfe32a/app/server.R#L798). This is valid as long as the locations reported by each score type are the same. Most of the time, that's true; WIS, absolute error, and sharpness/spread all use the selected location.

    However, regardless of which location is selected, coverage aggregates scores over states that have forecasts reported by all selected forecasters. This means that when changing to or from "coverage" and any single state or "US" is selected as the location (that is, we are not aggregating over shared locations), the displayed truth data will be incorrect if we just show the pre-existing plot. So we want to regenerate the truth plot by setting the flag that controls that behavior, `USE_CURR_TRUTH`, to `FALSE` in this case.

2. The old code was calling `updateAsOfData()` in some cases (only when the selected location was "US" -- what about other single locations?). We do need to do that to make sure the truth data is relevant, either invalidating cached as-of truth data or fetching new as-of truth data.

    However, when we're not requesting as-of truth data, `updateAsOfData()` also [sets `RE_RENDER_TRUTH` to `TRUE`](https://github.com/cmu-delphi/forecast-eval/blob/49896afaece66985f0b0d59c3eab1dee20bfe32a/app/server.R#L932). This flag [causes `summaryPlot()` to not generate a new main plot](https://github.com/cmu-delphi/forecast-eval/blob/49896afaece66985f0b0d59c3eab1dee20bfe32a/app/server.R#L341-L346) showing forecaster scores. We need to reset `RE_RENDER_TRUTH` to `FALSE`.

### Fixes
Logan [described the following issue](https://delphi-org.slack.com/archives/C01H63T0QE7/p1682012756484679) on Slack:

> Somehow by selecting a few teams... I reached a mode where switching from WIS to coverage would not plot on the main tab, but I could switch back to WIS and it would again show the WIS plot, and I could switch to the archive tab, switch to coverage, switch back to main tab, and coverage plots would show.  And the same thing going from coverage to WIS plots.
> ...
> Somehow I switched to "US" as the location accidentally / forgot; thought I was still on the state totals.  If you have US selected then that triggers the non-plotting behavior I mentioned.