### PR TITLE
regenerate truth plot if aggregating over shared states

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -809,6 +809,15 @@ server <- function(input, output, session) {
     updateLocationChoices(session, df, input$targetVariable, input$forecasters, input$location)
     updateCoverageChoices(session, df, input$targetVariable, input$forecasters, input$coverageInterval, output)
     USE_CURR_TRUTH <<- TRUE
+
+    # When aggregating over shared locations (i.e. either when coverage is
+    # selected or when the "Total over states" location option is selected),
+    # we need to regenerate the truth plot when any new forecaster is added
+    # in case it changes the common location set.
+    if (input$scoreType == "coverage" || input$location == TOTAL_LOCATIONS) {
+      # Need to create new truth plot.
+      USE_CURR_TRUTH <<- FALSE
+    }
   })
 
   observeEvent(input$scaleByBaseline, {


### PR DESCRIPTION
If change selected forecasters when using the "Total shared states" location option, truth data previously wouldn't update if the common locations changed. Fix that.