### PR TITLE
Repair CSV export tool

### DIFF
--- a/app/R/exportScores.R
+++ b/app/R/exportScores.R
@@ -5,7 +5,7 @@ exportScoresUI <- function(id = "exportScores") {
   )
 }
 
-createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, forecasters, loc, coverageInterval) {
+createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, forecasters, loc, coverageInterval, filterDate) {
   scoreDf <- filter(
     scoreDf[[targetVariable]],
     forecaster %chin% forecasters
@@ -16,7 +16,7 @@ createExportScoresDataFrame <- function(scoreDf, targetVariable, scoreType, fore
     if (targetVariable == "Hospitalizations") {
       scoreDf <- filterHospitalizationsAheads(scoreDf)
     }
-    scoreDf <- filterOverAllLocations(scoreDf, scoreType)
+    scoreDf <- filterOverAllLocations(scoreDf, scoreType, filterDate = filterDate)
     return(scoreDf[[1]])
   } else {
     scoreDf <- filter(scoreDf, geo_value == tolower(loc))

--- a/app/server.R
+++ b/app/server.R
@@ -991,7 +991,8 @@ server <- function(input, output, session) {
     "exportScores", shiny::reactive(generateExportFilename(input)),
     shiny::reactive(createExportScoresDataFrame(
       df_list, input$targetVariable, input$scoreType, input$forecasters,
-      input$location, input$coverageInterval, filterDate = dataCreationDate
+      input$location, input$coverageInterval,
+      filterDate = dataCreationDate
     ))
   )
 }

--- a/app/server.R
+++ b/app/server.R
@@ -991,7 +991,7 @@ server <- function(input, output, session) {
     "exportScores", shiny::reactive(generateExportFilename(input)),
     shiny::reactive(createExportScoresDataFrame(
       df_list, input$targetVariable, input$scoreType, input$forecasters,
-      input$location, input$coverageInterval
+      input$location, input$coverageInterval, filterDate = dataCreationDate
     ))
   )
 }


### PR DESCRIPTION
Pass `dataCreationDate` to CSV download filter, as in the [aggregation step used for plotting](https://github.com/cmu-delphi/forecast-eval/blob/590efb8c236bc08f3f5e7081c4d7dc6d5066b0ec/app/server.R#L238), since the exported data is intended to match that used to create the current plot.

Fixes https://github.com/cmu-delphi/forecast-eval/issues/284. Fixes https://github.com/cmu-delphi/forecast-eval/issues/256 apparently -- I can't reproduce anymore. It's possible that the issue was resolved due to a package update.