### PR TITLE
docs: add links to forecast-actual format repos

### DIFF
--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -139,4 +139,6 @@ These files are static, generated using [the aggregation script](link TBD), and 
   * 2 week: 2023-06-05
   * 3 week: 2023-06-05
   * 4 week: 2023-06-05
-* [deaths](https://www.stat.berkeley.edu/~ryantibs/data/deaths.zip): 2023-03-06
+* [deaths](https://forecast-eval.s3.us-east-2.amazonaws.com/deaths.zip): 2023-03-06
+
+If the S3 bucket is down, these files are also available on [Delphi's file-hosting site](https://www.cmu.edu/delphi-web/forecast-eval-scores).

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -133,8 +133,8 @@ stateCases = tryCatch(
 If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
 These files are static, generated using [the aggregation script](link TBD), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
 
-* [cases](https://www.stat.berkeley.edu/~ryantibs/data/cases.zip): 2023-02-13
-* [hospitalizations](https://www.stat.berkeley.edu/~ryantibs/data/hospitalizations.zip):
+* [cases](https://forecast-eval.s3.us-east-2.amazonaws.com/cases.zip): 2023-02-13
+* [hospitalizations](https://forecast-eval.s3.us-east-2.amazonaws.com/hospitalizations.zip):
   * 1 week: 2023-06-05
   * 2 week: 2023-06-05
   * 3 week: 2023-06-05

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -2,20 +2,20 @@
 
 This dashboard was developed by:
 
-- Chris Scott (Delphi Group, Google Fellow)
-- Kate Harwood (Delphi Group, Google Fellow)
-- Jed Grabman (Delphi Group, Google Fellow)
+* Chris Scott (Delphi Group, Google Fellow)
+* Kate Harwood (Delphi Group, Google Fellow)
+* Jed Grabman (Delphi Group, Google Fellow)
 
 with the Forecast Evaluation Research Collaborative:
 
-- Ryan Tibshirani (Delphi Group)
-- Nicholas Reich (Reich Lab)
-- Evan Ray (Reich Lab)
-- Daniel McDonald (Delphi Group)
-- Estee Cramer (Reich Lab)
-- Logan Brooks (Delphi Group)
-- Johannes Bracher (Karlsruhe Institute)
-- Jacob Bien (Delphi Group)
+* Ryan Tibshirani (Delphi Group)
+* Nicholas Reich (Reich Lab)
+* Evan Ray (Reich Lab)
+* Daniel McDonald (Delphi Group)
+* Estee Cramer (Reich Lab)
+* Logan Brooks (Delphi Group)
+* Johannes Bracher (Karlsruhe Institute)
+* Jacob Bien (Delphi Group)
 
 Forecast data in all states and U.S. territories are supplied by:
 
@@ -25,17 +25,17 @@ Forecast data in all states and U.S. territories are supplied by:
 
 The Forecast Evaluation Research Collaborative was founded by:
 
-- Carnegie Mellon University [Delphi Group](https://delphi.cmu.edu)
-- UMass-Amherst [Reich Lab](https://reichlab.io/)
+* Carnegie Mellon University [Delphi Group](https://delphi.cmu.edu)
+* UMass-Amherst [Reich Lab](https://reichlab.io/)
 
-Both groups are funded by the CDC as Centers of Excellence for Influenza and COVID-19 Forecasting. We have partnered together on this project to focus on providing a robust set of tools and methods for evaluating the performance of epidemic forecasts.
-
-The collaborative’s mission is to help epidemiological researchers gain insights into the performance of their forecasts and lead to more accurate forecasting of epidemics.
-
+Both groups are funded by the CDC as Centers of Excellence for Influenza and COVID-19 Forecasting. We have partnered together on this project to focus on providing a robust set of tools and methods for evaluating the performance of epidemic forecasts.  
+  
+The collaborative’s mission is to help epidemiological researchers gain insights into the performance of their forecasts and lead to more accurate forecasting of epidemics.  
+  
 Both groups lead initiatives related to COVID-19 data and forecast curation. The Reich Lab created and maintains the [COVID-19 Forecast Hub](https://covid19forecasthub.org/), a collaborative effort with over 80 groups submitting forecasts to be part of the official [CDC COVID-19 ensemble forecast](https://www.cdc.gov/coronavirus/2019-ncov/covid-data/mathematical-modeling.html). The Delphi Group created and maintains COVIDcast, a platform for [epidemiological surveillance data](https://delphi.cmu.edu/covidcast/), and runs the [U.S. COVID-19 Trends and Impact Survey in partnership with Facebook](https://delphi.cmu.edu/covidcast/surveys/).
-
-The Forecaster Evaluation Dashboard is a collaborative project, which has been made possible by the 13 pro bono Google.org Fellows who have spent 6 months working full-time with the Delphi Group. Google.org is [committed](https://www.google.org/covid-19/) to the recovery of lives and communities that have been impacted by COVID-19 and investing in developing the science to mitigate the damage of future pandemics.
-
+  
+The Forecaster Evaluation Dashboard is a collaborative project, which has been made possible by the 13 pro bono Google.org Fellows who have spent 6 months working full-time with the Delphi Group. Google.org is [committed](https://www.google.org/covid-19/) to the recovery of lives and communities that have been impacted by COVID-19 and investing in developing the science to mitigate the damage of future pandemics.  
+  
 ### About the Data
 
 #### **Sources**
@@ -43,51 +43,50 @@ The Forecaster Evaluation Dashboard is a collaborative project, which has been m
 **Observed cases and deaths** are from the [COVID-19 Data Repository](https://github.com/CSSEGISandData/COVID-19) by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University.
 
 **Observed hospitalizations** are from the U.S. Department of Health & Human Services and is the sum of all adult and pediatric COVID-19 hospital admissions.
-
-**Forecaster predictions** are drawn from the [COVID-19 Forecast Hub GitHub repository](https://github.com/reichlab/covid19-forecast-hub/)
-
+  
+**Forecaster predictions** are drawn from the [COVID-19 Forecast Hub GitHub repository](https://github.com/reichlab/covid19-forecast-hub/)  
+  
 Data for the dashboard is pulled from these sources on Sunday, Monday, and Tuesday each week.
 
 #### **Terms**
 
-- **Forecaster**: A named model that produces forecasts, e.g., "COVIDhub-ensemble"
-- **Forecast**: A set of quantile predictions for a specific target variable, epidemiological week, and location
-- **Target Variable**: What the forecast is predicting, e.g., “weekly incident cases”
-- **Epidemiological week (MMWR week)**: A standardized week that starts on a Sunday. See the [CDC definition](https://wwwn.cdc.gov/nndss/document/MMWR_week_overview.pdf) for additional details.
+*   **Forecaster**:  A named model that produces forecasts, e.g., "COVIDhub-ensemble"
+    
+*   **Forecast**: A set of quantile predictions for a specific target variable, epidemiological week, and location 
+    
+*   **Target Variable**: What the forecast is predicting, e.g., “weekly incident cases”
+        
+*   **Epidemiological week (MMWR week)**: A standardized week that starts on a Sunday. See the [CDC definition](https://wwwn.cdc.gov/nndss/document/MMWR_week_overview.pdf) for additional details.
 
-- **Horizon**: The duration of time between when a prediction was made and the end of the corresponding epidemiological week. Following the [Reich Lab definition](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/README.md#target), a forecast has a horizon of 1 week if it was produced no later than the Monday of the epidemiological week it forecasts. Thus, forecasts made 5-11 days before the end of the corresponding epidemiological week have a horizon of 1 week, 12-18 days before have a horizon of 2 weeks, etc.
-
+*   **Horizon**: The duration of time between when a prediction was made and the end of the corresponding epidemiological week. Following the [Reich Lab definition](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/README.md#target), a forecast has a horizon of 1 week if it was produced no later than the Monday of the epidemiological week it forecasts. Thus, forecasts made 5-11 days before the end of the corresponding epidemiological week have a horizon of 1 week, 12-18 days before have a horizon of 2 weeks, etc. 
+  
 #### **Dashboard Inclusion Criteria**
-
 A forecast is only included if all the following criteria are met:
 
-- The target variable is the weekly incidence of either cases or deaths, or the daily incidence of hospitalizations
-- The horizon is no more than 4 weeks ahead
-- The location is a U.S. state, territory, or the nation as a whole
-- All dates are parsable. If a date is not in yyyy/mm/dd format, the forecast may be dropped.
-- The forecast was made on or before the Monday of the relevant week. If multiple versions of a forecast are submitted then only the last forecast that meets the date restriction is included.
+*   The target variable is the weekly incidence of either cases or deaths, or the daily incidence of hospitalizations
+*   The horizon is no more than 4 weeks ahead
+*   The location is a U.S. state, territory, or the nation as a whole
+*   All dates are parsable. If a date is not in yyyy/mm/dd format, the forecast may be dropped.
+*   The forecast was made on or before the Monday of the relevant week. If multiple versions of a forecast are submitted then only the last forecast that meets the date restriction is included.
 
 #### **How Hospitalization Forecasts are Processed**
-
 Though hospitalizations are forecasted on a daily basis, in keeping with the cases and death scoring and plotting, we show the hospitalization scores on a weekly basis in the dashboard. We only look at forecasts for one target day a week (currently Wednesdays), and calculate the weekly horizons accordingly. Hospitalization horizons are calculated in the following manner:
-
-- 2 days ahead: Forecast date is on or before the Monday preceeding the target date (Wednesday)
-- 9 days ahead: Forecast date equal to or before 7 days before the Monday preceeding the target date
-- 16 days ahead: Forecast date is equal to or before 14 days before the Monday preceeding the target date
-- 23 days ahead: Forecast date equal to or before 21 days before the Monday preceeding the target date
+* 2 days ahead: Forecast date is on or before the Monday preceeding the target date (Wednesday)
+* 9 days ahead: Forecast date equal to or before 7 days before the Monday preceeding the target date
+* 16 days ahead: Forecast date is equal to or before 14 days before the Monday preceeding the target date
+* 23 days ahead: Forecast date equal to or before 21 days before the Monday preceeding the target date
 
 #### **Notes on the Data**
 
-- If a forecast does not include an explicit point estimate, the 0.5 quantile is taken as the point estimate for calculating absolute error.
-- The weighted interval score is only shown for forecasts that have predictions for all quantiles (23 quantiles for deaths and hospitalizations and 7 for cases)
-- Totaling over all states and territories does not include nationwide forecasts. To ensure that values are comparable, these totals also exclude any locations that are absent from any file that was submitted by one of the selected forecasters.
-- For scoring, we include revisions of observed values, which means that the scores for forecasts made in the past can change as our understanding of the ground truth changes.
-- The observed data can also be viewed **'as of'** a certain date, which shows what observed data a forecaster had available
-  when a past forecast was made (but the forecasts are always scored on the latest revision of the observed data).
+*   If a forecast does not include an explicit point estimate, the 0.5 quantile is taken as the point estimate for calculating absolute error.
+*   The weighted interval score is only shown for forecasts that have predictions for all quantiles (23 quantiles for deaths and hospitalizations and 7 for cases)
+*   Totaling over all states and territories does not include nationwide forecasts. To ensure that values are comparable, these totals also exclude any locations that are absent from any file that was submitted by one of the selected forecasters.
+*   For scoring, we include revisions of observed values, which means that the scores for forecasts made in the past can change as our understanding of the ground truth changes.
+*   The observed data can also be viewed **'as of'** a certain date, which shows what observed data a forecaster had available
+when a past forecast was made (but the forecasts are always scored on the latest revision of the observed data).
 
 #### **Accessing the Data**
-
-The forecasts and scores are available as RDS files and are uploaded weekly to a publicly accessible AWS bucket.
+The forecasts and scores are available as RDS files and are uploaded weekly to a publicly accessible AWS bucket.  
 
 You can use the url https://forecast-eval.s3.us-east-2.amazonaws.com/ + filename to download
 any of the files from the bucket.
@@ -95,14 +94,13 @@ any of the files from the bucket.
 For instance: https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_nation_cases.rds to download scores for nation level case predictions.
 
 The available files are:
-
-- predictions_cards.rds (forecasts)
-- score_cards_nation_cases.rds
-- score_cards_nation_deaths.rds
-- score_cards_state_cases.rds
-- score_cards_state_deaths.rds
-- score_cards_state_hospitalizations.rds
-- score_cards_nation_hospitalizations.rds
+* predictions_cards.rds (forecasts)
+* score_cards_nation_cases.rds
+* score_cards_nation_deaths.rds
+* score_cards_state_cases.rds
+* score_cards_state_deaths.rds
+* score_cards_state_hospitalizations.rds
+* score_cards_nation_hospitalizations.rds
 
 You can also connect to AWS and retrieve the data in R. Example of retrieving state cases file:
 
@@ -127,16 +125,18 @@ stateCases = tryCatch(
   }
 )
 ```
+  
+  
 
 ##### Forecast evaluation
 
 If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
 These files are static, and the latest forecast date is
 
-- [cases](https://www.stat.berkeley.edu/~ryantibs/data/cases.zip): 2023-02-13
-- [hospitalizations](https://www.stat.berkeley.edu/~ryantibs/data/hospitalizations.zip):
-  - 1 week: 2023-06-05
-  - 2 week: 2023-06-05
-  - 3 week: 2023-06-05
-  - 4 week: 2023-06-05
-- [deaths](https://www.stat.berkeley.edu/~ryantibs/data/deaths.zip): 2023-03-06
+* [cases](https://www.stat.berkeley.edu/~ryantibs/data/cases.zip): 2023-02-13
+* [hospitalizations](https://www.stat.berkeley.edu/~ryantibs/data/hospitalizations.zip):
+  * 1 week: 2023-06-05
+  * 2 week: 2023-06-05
+  * 3 week: 2023-06-05
+  * 4 week: 2023-06-05
+* [deaths](https://www.stat.berkeley.edu/~ryantibs/data/deaths.zip): 2023-03-06

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -131,7 +131,7 @@ stateCases = tryCatch(
 ##### Forecasts with actuals
 
 If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
-These files are static, and the latest forecast date is
+These files are static, generated using [the aggregation script](link TBD), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
 
 * [cases](https://www.stat.berkeley.edu/~ryantibs/data/cases.zip): 2023-02-13
 * [hospitalizations](https://www.stat.berkeley.edu/~ryantibs/data/hospitalizations.zip):

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -2,20 +2,20 @@
 
 This dashboard was developed by:
 
-* Chris Scott (Delphi Group, Google Fellow)
-* Kate Harwood (Delphi Group, Google Fellow)
-* Jed Grabman (Delphi Group, Google Fellow)
+- Chris Scott (Delphi Group, Google Fellow)
+- Kate Harwood (Delphi Group, Google Fellow)
+- Jed Grabman (Delphi Group, Google Fellow)
 
 with the Forecast Evaluation Research Collaborative:
 
-* Ryan Tibshirani (Delphi Group)
-* Nicholas Reich (Reich Lab)
-* Evan Ray (Reich Lab)
-* Daniel McDonald (Delphi Group)
-* Estee Cramer (Reich Lab)
-* Logan Brooks (Delphi Group)
-* Johannes Bracher (Karlsruhe Institute)
-* Jacob Bien (Delphi Group)
+- Ryan Tibshirani (Delphi Group)
+- Nicholas Reich (Reich Lab)
+- Evan Ray (Reich Lab)
+- Daniel McDonald (Delphi Group)
+- Estee Cramer (Reich Lab)
+- Logan Brooks (Delphi Group)
+- Johannes Bracher (Karlsruhe Institute)
+- Jacob Bien (Delphi Group)
 
 Forecast data in all states and U.S. territories are supplied by:
 
@@ -25,17 +25,17 @@ Forecast data in all states and U.S. territories are supplied by:
 
 The Forecast Evaluation Research Collaborative was founded by:
 
-* Carnegie Mellon University [Delphi Group](https://delphi.cmu.edu)
-* UMass-Amherst [Reich Lab](https://reichlab.io/)
+- Carnegie Mellon University [Delphi Group](https://delphi.cmu.edu)
+- UMass-Amherst [Reich Lab](https://reichlab.io/)
 
-Both groups are funded by the CDC as Centers of Excellence for Influenza and COVID-19 Forecasting. We have partnered together on this project to focus on providing a robust set of tools and methods for evaluating the performance of epidemic forecasts.  
-  
-The collaborative’s mission is to help epidemiological researchers gain insights into the performance of their forecasts and lead to more accurate forecasting of epidemics.  
-  
+Both groups are funded by the CDC as Centers of Excellence for Influenza and COVID-19 Forecasting. We have partnered together on this project to focus on providing a robust set of tools and methods for evaluating the performance of epidemic forecasts.
+
+The collaborative’s mission is to help epidemiological researchers gain insights into the performance of their forecasts and lead to more accurate forecasting of epidemics.
+
 Both groups lead initiatives related to COVID-19 data and forecast curation. The Reich Lab created and maintains the [COVID-19 Forecast Hub](https://covid19forecasthub.org/), a collaborative effort with over 80 groups submitting forecasts to be part of the official [CDC COVID-19 ensemble forecast](https://www.cdc.gov/coronavirus/2019-ncov/covid-data/mathematical-modeling.html). The Delphi Group created and maintains COVIDcast, a platform for [epidemiological surveillance data](https://delphi.cmu.edu/covidcast/), and runs the [U.S. COVID-19 Trends and Impact Survey in partnership with Facebook](https://delphi.cmu.edu/covidcast/surveys/).
-  
-The Forecaster Evaluation Dashboard is a collaborative project, which has been made possible by the 13 pro bono Google.org Fellows who have spent 6 months working full-time with the Delphi Group. Google.org is [committed](https://www.google.org/covid-19/) to the recovery of lives and communities that have been impacted by COVID-19 and investing in developing the science to mitigate the damage of future pandemics.  
-  
+
+The Forecaster Evaluation Dashboard is a collaborative project, which has been made possible by the 13 pro bono Google.org Fellows who have spent 6 months working full-time with the Delphi Group. Google.org is [committed](https://www.google.org/covid-19/) to the recovery of lives and communities that have been impacted by COVID-19 and investing in developing the science to mitigate the damage of future pandemics.
+
 ### About the Data
 
 #### **Sources**
@@ -43,50 +43,51 @@ The Forecaster Evaluation Dashboard is a collaborative project, which has been m
 **Observed cases and deaths** are from the [COVID-19 Data Repository](https://github.com/CSSEGISandData/COVID-19) by the Center for Systems Science and Engineering (CSSE) at Johns Hopkins University.
 
 **Observed hospitalizations** are from the U.S. Department of Health & Human Services and is the sum of all adult and pediatric COVID-19 hospital admissions.
-  
-**Forecaster predictions** are drawn from the [COVID-19 Forecast Hub GitHub repository](https://github.com/reichlab/covid19-forecast-hub/)  
-  
+
+**Forecaster predictions** are drawn from the [COVID-19 Forecast Hub GitHub repository](https://github.com/reichlab/covid19-forecast-hub/)
+
 Data for the dashboard is pulled from these sources on Sunday, Monday, and Tuesday each week.
 
 #### **Terms**
 
-*   **Forecaster**:  A named model that produces forecasts, e.g., "COVIDhub-ensemble"
-    
-*   **Forecast**: A set of quantile predictions for a specific target variable, epidemiological week, and location 
-    
-*   **Target Variable**: What the forecast is predicting, e.g., “weekly incident cases”
-        
-*   **Epidemiological week (MMWR week)**: A standardized week that starts on a Sunday. See the [CDC definition](https://wwwn.cdc.gov/nndss/document/MMWR_week_overview.pdf) for additional details.
+- **Forecaster**: A named model that produces forecasts, e.g., "COVIDhub-ensemble"
+- **Forecast**: A set of quantile predictions for a specific target variable, epidemiological week, and location
+- **Target Variable**: What the forecast is predicting, e.g., “weekly incident cases”
+- **Epidemiological week (MMWR week)**: A standardized week that starts on a Sunday. See the [CDC definition](https://wwwn.cdc.gov/nndss/document/MMWR_week_overview.pdf) for additional details.
 
-*   **Horizon**: The duration of time between when a prediction was made and the end of the corresponding epidemiological week. Following the [Reich Lab definition](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/README.md#target), a forecast has a horizon of 1 week if it was produced no later than the Monday of the epidemiological week it forecasts. Thus, forecasts made 5-11 days before the end of the corresponding epidemiological week have a horizon of 1 week, 12-18 days before have a horizon of 2 weeks, etc. 
-  
+- **Horizon**: The duration of time between when a prediction was made and the end of the corresponding epidemiological week. Following the [Reich Lab definition](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/README.md#target), a forecast has a horizon of 1 week if it was produced no later than the Monday of the epidemiological week it forecasts. Thus, forecasts made 5-11 days before the end of the corresponding epidemiological week have a horizon of 1 week, 12-18 days before have a horizon of 2 weeks, etc.
+
 #### **Dashboard Inclusion Criteria**
+
 A forecast is only included if all the following criteria are met:
 
-*   The target variable is the weekly incidence of either cases or deaths, or the daily incidence of hospitalizations
-*   The horizon is no more than 4 weeks ahead
-*   The location is a U.S. state, territory, or the nation as a whole
-*   All dates are parsable. If a date is not in yyyy/mm/dd format, the forecast may be dropped.
-*   The forecast was made on or before the Monday of the relevant week. If multiple versions of a forecast are submitted then only the last forecast that meets the date restriction is included.
+- The target variable is the weekly incidence of either cases or deaths, or the daily incidence of hospitalizations
+- The horizon is no more than 4 weeks ahead
+- The location is a U.S. state, territory, or the nation as a whole
+- All dates are parsable. If a date is not in yyyy/mm/dd format, the forecast may be dropped.
+- The forecast was made on or before the Monday of the relevant week. If multiple versions of a forecast are submitted then only the last forecast that meets the date restriction is included.
 
 #### **How Hospitalization Forecasts are Processed**
+
 Though hospitalizations are forecasted on a daily basis, in keeping with the cases and death scoring and plotting, we show the hospitalization scores on a weekly basis in the dashboard. We only look at forecasts for one target day a week (currently Wednesdays), and calculate the weekly horizons accordingly. Hospitalization horizons are calculated in the following manner:
-* 2 days ahead: Forecast date is on or before the Monday preceeding the target date (Wednesday)
-* 9 days ahead: Forecast date equal to or before 7 days before the Monday preceeding the target date
-* 16 days ahead: Forecast date is equal to or before 14 days before the Monday preceeding the target date
-* 23 days ahead: Forecast date equal to or before 21 days before the Monday preceeding the target date
+
+- 2 days ahead: Forecast date is on or before the Monday preceeding the target date (Wednesday)
+- 9 days ahead: Forecast date equal to or before 7 days before the Monday preceeding the target date
+- 16 days ahead: Forecast date is equal to or before 14 days before the Monday preceeding the target date
+- 23 days ahead: Forecast date equal to or before 21 days before the Monday preceeding the target date
 
 #### **Notes on the Data**
 
-*   If a forecast does not include an explicit point estimate, the 0.5 quantile is taken as the point estimate for calculating absolute error.
-*   The weighted interval score is only shown for forecasts that have predictions for all quantiles (23 quantiles for deaths and hospitalizations and 7 for cases)
-*   Totaling over all states and territories does not include nationwide forecasts. To ensure that values are comparable, these totals also exclude any locations that are absent from any file that was submitted by one of the selected forecasters.
-*   For scoring, we include revisions of observed values, which means that the scores for forecasts made in the past can change as our understanding of the ground truth changes.
-*   The observed data can also be viewed **'as of'** a certain date, which shows what observed data a forecaster had available
-when a past forecast was made (but the forecasts are always scored on the latest revision of the observed data).
+- If a forecast does not include an explicit point estimate, the 0.5 quantile is taken as the point estimate for calculating absolute error.
+- The weighted interval score is only shown for forecasts that have predictions for all quantiles (23 quantiles for deaths and hospitalizations and 7 for cases)
+- Totaling over all states and territories does not include nationwide forecasts. To ensure that values are comparable, these totals also exclude any locations that are absent from any file that was submitted by one of the selected forecasters.
+- For scoring, we include revisions of observed values, which means that the scores for forecasts made in the past can change as our understanding of the ground truth changes.
+- The observed data can also be viewed **'as of'** a certain date, which shows what observed data a forecaster had available
+  when a past forecast was made (but the forecasts are always scored on the latest revision of the observed data).
 
 #### **Accessing the Data**
-The forecasts and scores are available as RDS files and are uploaded weekly to a publicly accessible AWS bucket.  
+
+The forecasts and scores are available as RDS files and are uploaded weekly to a publicly accessible AWS bucket.
 
 You can use the url https://forecast-eval.s3.us-east-2.amazonaws.com/ + filename to download
 any of the files from the bucket.
@@ -94,13 +95,14 @@ any of the files from the bucket.
 For instance: https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_nation_cases.rds to download scores for nation level case predictions.
 
 The available files are:
-* predictions_cards.rds (forecasts)
-* score_cards_nation_cases.rds
-* score_cards_nation_deaths.rds
-* score_cards_state_cases.rds
-* score_cards_state_deaths.rds
-* score_cards_state_hospitalizations.rds
-* score_cards_nation_hospitalizations.rds
+
+- predictions_cards.rds (forecasts)
+- score_cards_nation_cases.rds
+- score_cards_nation_deaths.rds
+- score_cards_state_cases.rds
+- score_cards_state_deaths.rds
+- score_cards_state_hospitalizations.rds
+- score_cards_nation_hospitalizations.rds
 
 You can also connect to AWS and retrieve the data in R. Example of retrieving state cases file:
 
@@ -125,5 +127,16 @@ stateCases = tryCatch(
   }
 )
 ```
-  
-  
+
+##### Forecast evaluation
+
+If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
+These files are static, and the latest forecast date is
+
+- [cases](https://www.stat.berkeley.edu/~ryantibs/data/cases.zip): 2023-02-13
+- [hospitalizations](https://www.stat.berkeley.edu/~ryantibs/data/hospitalizations.zip):
+  - 1 week: 2023-06-05
+  - 2 week: 2023-06-05
+  - 3 week: 2023-06-05
+  - 4 week: 2023-06-05
+- [deaths](https://www.stat.berkeley.edu/~ryantibs/data/deaths.zip): 2023-03-06

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -131,7 +131,7 @@ stateCases = tryCatch(
 ##### Forecasts with actuals
 
 If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
-These files are static, generated using [the aggregation script](link TBD), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
+These files are static, generated using [the aggregation script](https://raw.githubusercontent.com/cmu-delphi/forecast-eval/main/app/assets/forecastsWithActuals.md), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
 
 * [cases](https://forecast-eval.s3.us-east-2.amazonaws.com/cases.zip): 2023-02-13
 * [hospitalizations](https://forecast-eval.s3.us-east-2.amazonaws.com/hospitalizations.zip):

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -130,8 +130,8 @@ stateCases = tryCatch(
 
 ##### Forecasts with actuals
 
-If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
-These files are static, generated using [the aggregation script](https://raw.githubusercontent.com/cmu-delphi/forecast-eval/main/app/assets/forecastsWithActuals.md), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
+If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found in [the Amazon S3 bucket](https://forecast-eval.s3.us-east-2.amazonaws.com/) in 3 zip files.
+These files are static, generated using [the aggregation script](https://raw.githubusercontent.com/cmu-delphi/forecast-eval/main/app/assets/forecastsWithActuals.R), and forecast and actual data available on June 12, 2023. The latest forecast date available for each target signal is
 
 * [cases](https://forecast-eval.s3.us-east-2.amazonaws.com/cases.zip): 2023-02-13
 * [hospitalizations](https://forecast-eval.s3.us-east-2.amazonaws.com/hospitalizations.zip):

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -128,7 +128,7 @@ stateCases = tryCatch(
   
   
 
-##### Forecast evaluation
+##### Forecasts with actuals
 
 If you are interested in getting the forecasts paired with the corresponding actual values (if you were e.g. testing different evaluation methods), that can be found at [https://www.stat.berkeley.edu/~ryantibs/data/](https://www.stat.berkeley.edu/~ryantibs/data/ "this is a temporary home") in 3 (zipped) zip files.
 These files are static, and the latest forecast date is

--- a/app/assets/forecastsWithActuals.R
+++ b/app/assets/forecastsWithActuals.R
@@ -1,0 +1,98 @@
+library(dplyr)
+library(tidyr)
+library(aws.s3)
+
+Sys.setenv("AWS_DEFAULT_REGION" = "us-east-2")
+s3bucket <- tryCatch(
+  {
+    get_bucket(bucket = "forecast-eval")
+  },
+  error = function(e) {
+    e
+  }
+)
+
+readbucket <- function(name) {
+  tryCatch(
+    {
+      s3readRDS(object = name, bucket = s3bucket)
+    },
+    error = function(e) {
+      e
+    }
+  )
+}
+
+# Cases, deaths, hosp scores: needed for "actual"s
+cases <- bind_rows(
+  readbucket("score_cards_nation_cases.rds"),
+  readbucket("score_cards_state_cases.rds")
+)
+deaths <- bind_rows(
+  readbucket("score_cards_nation_deaths.rds"),
+  readbucket("score_cards_state_deaths.rds")
+)
+hosp <- bind_rows(
+  readbucket("score_cards_nation_hospitalizations.rds"),
+  readbucket("score_cards_state_hospitalizations.rds")
+)
+
+# The big one: predictions from all forecasters
+pred <- readbucket("predictions_cards.rds")
+
+# Cases
+pred_cases <- pred %>%
+  filter(signal == "confirmed_incidence_num") %>%
+  mutate(signal = NULL, data_source = NULL, incidence_period = NULL) %>%
+  pivot_wider(
+    names_from = quantile,
+    values_from = value,
+    names_prefix = "forecast_"
+  )
+
+actual_cases <- cases %>%
+  select(ahead, geo_value, forecaster, forecast_date, target_end_date, actual)
+
+joined_cases <- left_join(pred_cases, actual_cases)
+sum(is.na(actual_cases$actual)) == sum(is.na(joined_cases$actual))
+write.csv(joined_cases, "cases.csv")
+
+# Deaths
+pred_deaths <- pred %>%
+  filter(signal == "deaths_incidence_num") %>%
+  mutate(signal = NULL, data_source = NULL, incidence_period = NULL) %>%
+  pivot_wider(
+    names_from = quantile,
+    values_from = value,
+    names_prefix = "forecast_"
+  )
+
+actual_deaths <- deaths %>%
+  select(ahead, geo_value, forecaster, forecast_date, target_end_date, actual)
+
+joined_deaths <- left_join(pred_deaths, actual_deaths)
+sum(is.na(actual_deaths$actual)) == sum(is.na(joined_deaths$actual))
+write.csv(joined_deaths, "deaths.csv")
+
+# Hospitalizations: break up by weeks since we run into memory errors o/w!
+pred_hosp <- actual_hosp <- joined_hosp <- vector(mode = "list", length = 4)
+for (k in 1:4) {
+  cat(k, "... ")
+  days <- (k - 1) * 7 + 1:7
+  pred_hosp[[k]] <- pred %>%
+    filter(signal == "confirmed_admissions_covid_1d", ahead %in% days) %>%
+    mutate(signal = NULL, data_source = NULL, incidence_period = NULL) %>%
+    pivot_wider(
+      names_from = quantile,
+      values_from = value,
+      names_prefix = "forecast_"
+    )
+
+  actual_hosp[[k]] <- hosp %>%
+    filter(ahead %in% days) %>%
+    select(ahead, geo_value, forecaster, forecast_date, target_end_date, actual)
+
+  joined_hosp[[k]] <- left_join(pred_hosp[[k]], actual_hosp[[k]])
+  cat(sum(is.na(actual_hosp[[k]]$act)) == sum(is.na(joined_hosp[[k]]$act)))
+  write.csv(joined_hosp[[k]], sprintf("hospitalizations_%iwk.csv", k))
+}


### PR DESCRIPTION
The actual location of the links is in limbo for a bit, and ideally we'd be regenerating this, but the static version would also be useful.