### PR TITLE
Reduce workflow warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,8 @@ jobs:
           if [ "$imageTag" = "main" ] ; then
             imageTag="latest"
           fi
-          echo "::set-output name=tag::$imageTag"
-          echo "::set-output name=repo::ghcr.io/${{ github.repository }}"
+          echo "tag=$imageTag" >> "$GITHUB_OUTPUT"
+          echo "repo=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
       - name: Push Dev Tag
         run: |
           docker tag repo ${{ steps.tagname.outputs.repo }}:${{ steps.tagname.outputs.tag }}
@@ -64,8 +64,8 @@ jobs:
         id: extract_version
         run: |
           python -m pip install bump2version
-          echo -n "::set-output name=version::"
-          bump2version --dry-run --list patch | grep ^current_version | sed -r s,"^.*=",,
+          currentVersion=`bump2version --dry-run --list patch | grep ^current_version | sed -r s,"^.*=",,`
+          echo "version=$currentVersion" >> "$GITHUB_OUTPUT"
       - name: Trigger Webhook
         run: |
           # trigger a webhook update

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Pull Image Data
         run: make pull_data
       - name: Login to GitHub Container Registry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Pull Image Data
         run: make pull_data
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: cmu-delphi-deploy-machine

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -27,8 +27,8 @@ jobs:
         id: version
         run: |
           python -m pip install bump2version
-          echo -n "::set-output name=next_tag::"
-          bump2version --list ${{ github.event.inputs.versionName }} | grep new_version | sed -r s,"^.*=",,
+          newVersion=`bump2version --list ${{ github.event.inputs.versionName }} | grep new_version | sed -r s,"^.*=",,`
+          echo "next_tag=$newVersion" >> "$GITHUB_OUTPUT"
       - name: Create pull request into main
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,7 +30,7 @@ jobs:
           echo -n "::set-output name=next_tag::"
           bump2version --list ${{ github.event.inputs.versionName }} | grep new_version | sed -r s,"^.*=",,
       - name: Create pull request into main
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           branch: release/${{ steps.version.outputs.next_tag }}
           commit-message: "chore: release ${{ steps.version.outputs.next_tag }}"

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -29,8 +29,8 @@ jobs:
         id: extract_version
         run: |
           python -m pip install bump2version
-          echo -n "::set-output name=version::"
-          bump2version --dry-run --list patch | grep ^current_version | sed -r s,"^.*=",,
+          currentVersion=`bump2version --dry-run --list patch | grep ^current_version | sed -r s,"^.*=",,`
+          echo "version=$currentVersion" >> "$GITHUB_OUTPUT"
       - name: Create Release
         id: create_release
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -31,14 +31,14 @@ jobs:
         run: aws --version
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: ${{ env.AWS_REGION_NAME }}
           
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: cmu-delphi-deploy-machine

--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         
       - name: Test AWS cli installation
         run: aws --version


### PR DESCRIPTION
Besides the [Node16 warnings](https://github.com/cmu-delphi/forecast-eval/pull/293), our workflows also have "The `set-output` command is deprecated and will be disabled soon" and "The `save-state` command is deprecated and will be disabled soon" errors, even in workflows that don't use those commands. I updated various actions we use to their newest versions incorporating the new Node version and environment files.

On workflows that use the `set-output` command, I replaced with the [`GITHUB_OUTPUT` file, as recommended](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).