### PR TITLE
Pass GITHUB_PAT from workflow to docker to authenticate new API-based date fetching

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -45,6 +45,8 @@ jobs:
           password: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
           
       - name: Deploy score files to S3 bucket
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make deploy
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PWD=$(shell pwd)
 .DEFAULT_GOAL:=build
 S3_URL=https://forecast-eval.s3.us-east-2.amazonaws.com
 S3_BUCKET=s3://forecast-eval
+# If not already set in calling environment, set PAT to an empty value.
+GITHUB_PAT?=
 
 # Change `imageTag` during `make` call via `make <command> imageTag=<tag name>`
 #
@@ -46,6 +48,7 @@ score_forecast: r_build dist pull_data
 		-v ${PWD}/Report:/var/forecast-eval \
 		-v ${PWD}/dist:/var/dist \
 		-w /var/forecast-eval \
+		-e GITHUB_PAT \
 		forecast-eval-build \
 		Rscript create_reports.R --dir /var/dist
 


### PR DESCRIPTION
`evalcast` now [uses the GitHub API to get forecast dates](https://github.com/cmu-delphi/covidcast/pull/647) ([authentication support added here](https://github.com/cmu-delphi/covidcast/pull/649)). Since the forecast eval pipeline makes a lot of date calls, it reaches the free-tier API call limit, so we need to use a PAT to get a higher rate limit.