### PR TITLE
Stop calculating deaths and cases scores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ r_build:
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@
 
 # Specify all the data files we want to download
-pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds predictions_cards.rds
+pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds
 
 # Create the dist directory
 dist:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ r_build:
 # Specify all the data files we want to download
 pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds
 
+# Download all the predictions cards objects. This is
+# useful for development and debugging
+pull_pred_cards: predictions_cards_confirmed_admissions_covid_1d.rds predictions_cards_confirmed_incidence_num.rds predictions_cards_deaths_incidence_num.rds
+
 # Create the dist directory
 dist:
 	mkdir $@

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -206,7 +206,7 @@ for (signal_name in signals) {
   }
 }
 
-rm(state_scores)
+rm(state_scores, state_predictions)
 gc()
 
 print("Evaluating national forecasts")

--- a/Report/create_reports.R
+++ b/Report/create_reports.R
@@ -3,6 +3,7 @@ library("optparse")
 library("dplyr")
 library("evalcast")
 library("lubridate")
+library("stringr")
 
 # TODO: Contains fixed versions of WIS component metrics, to be ported over to evalcast
 # Redefines overprediction, underprediction and sharpness
@@ -22,7 +23,7 @@ option_list <- list(
 opt_parser <- OptionParser(option_list = option_list)
 opt <- parse_args(opt_parser)
 output_dir <- opt$dir
-prediction_cards_filename <- "predictions_cards.rds"
+prediction_cards_filename <- "predictions_cards_${signal}.rds"
 prediction_cards_filepath <- case_when(
   !is.null(output_dir) ~ file.path(output_dir, prediction_cards_filename),
   TRUE ~ prediction_cards_filename
@@ -60,8 +61,6 @@ state_geos <- locations %>%
   filter(nchar(.data$geo_value) == 2) %>%
   pull(.data$geo_value)
 signals <- c(
-  "confirmed_incidence_num",
-  "deaths_incidence_num",
   "confirmed_admissions_covid_1d"
 )
 
@@ -105,10 +104,22 @@ predictions_cards <- predictions_cards %>%
 class(predictions_cards) <- c("predictions_cards", class(predictions_cards))
 
 print("Saving predictions...")
-saveRDS(predictions_cards,
-  file = prediction_cards_filepath,
-  compress = "xz"
-)
+if (length(signals) == 1) {
+  signal <- signals
+  saveRDS(predictions_cards,
+    file = str_interp(prediction_cards_filepath),
+    compress = "xz"
+  )
+} else {
+  # Save each signal separately.
+  for (signal_group in group_split(predictions_cards, signal)) {
+    signal <- signal_group$signal[1]
+    saveRDS(signal_group,
+      file = str_interp(prediction_cards_filepath),
+      compress = "xz"
+    )
+  }
+}
 print("Predictions saved")
 
 ## Create error measure functions


### PR DESCRIPTION
Closes #248.

Only hospital admissions predictions are still active; cases and deaths forecasts are no longer supported by Forecast Hub and the JHU truth data used to evaluate these is no longer being updated. This means that historical error metrics for cases and deaths are fixed, so we no longer need to calculate them.

The pipeline is still able to recalculate cases and deaths scores if we wish -- this only requires updating the `signals` vector. To make sure that these archived scores are still available for the dashboard, the relevant score RDS files are downloaded from the S3 bucket and then re-uploaded unmodified after the pipeline completes.