### PR TITLE
Store pipeline output in compressed CSVs and read/write them using `data.table`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ r_build:
 	docker build --no-cache --force-rm --pull -t forecast-eval-build docker_build
 
 # Download the named file from the AWS S3 bucket
-%.rds: dist
+%.csv.gz: dist
 	test -f dist/$@ || curl -o dist/$@ $(S3_URL)/$@
 
 # Specify all the data files we want to download
-pull_data: score_cards_state_deaths.rds score_cards_state_cases.rds score_cards_nation_cases.rds score_cards_nation_deaths.rds score_cards_state_hospitalizations.rds score_cards_nation_hospitalizations.rds datetime_created_utc.rds
+pull_data: score_cards_state_deaths.csv.gz score_cards_state_cases.csv.gz score_cards_nation_cases.csv.gz score_cards_nation_deaths.csv.gz score_cards_state_hospitalizations.csv.gz score_cards_nation_hospitalizations.csv.gz datetime_created_utc.csv.gz
 
 # Download all the predictions cards objects. This is
 # useful for development and debugging
-pull_pred_cards: predictions_cards_confirmed_admissions_covid_1d.rds predictions_cards_confirmed_incidence_num.rds predictions_cards_deaths_incidence_num.rds
+pull_pred_cards: predictions_cards_confirmed_admissions_covid_1d.csv.gz predictions_cards_confirmed_incidence_num.csv.gz predictions_cards_deaths_incidence_num.csv.gz
 
 # Create the dist directory
 dist:
@@ -59,7 +59,7 @@ score_forecast: r_build dist pull_data
 
 # Post scoring pipeline output files to the AWS S3 bucket
 deploy: score_forecast
-	aws s3 cp dist/ $(S3_BUCKET)/ --recursive --exclude "*" --include "*rds" --acl public-read
+	aws s3 cp dist/ $(S3_BUCKET)/ --recursive --exclude "*" --include "*csv.gz" --acl public-read
 
 # Run bash in a docker container with a full preconfigured R environment
 #

--- a/Report/score.R
+++ b/Report/score.R
@@ -1,5 +1,4 @@
 library("dplyr")
-library("data.table")
 library("assertthat")
 
 type_map <- list(

--- a/Report/score.R
+++ b/Report/score.R
@@ -1,4 +1,5 @@
 library("dplyr")
+library("data.table")
 library("assertthat")
 
 type_map <- list(
@@ -13,7 +14,7 @@ generate_score_card_file_path <- function(geo_type, signal_name, output_dir) {
     output_dir,
     paste0(
       "score_cards_", geo_type, "_",
-      sig_suffix, ".rds"
+      sig_suffix, ".csv.gz"
     )
   )
   return(output_file_name)
@@ -44,10 +45,7 @@ save_score_cards <- function(score_card, geo_type = c("state", "nation"),
   }
 
   output_file_name <- generate_score_card_file_path(geo_type, signal_name, output_dir)
-  saveRDS(score_card,
-    file = output_file_name,
-    compress = "xz"
-  )
+  fwrite(score_card, file = output_file_name)
 }
 
 save_score_cards_wrapper <- function(score_card, geo_type, signal_name, output_dir) {

--- a/Report/utils.R
+++ b/Report/utils.R
@@ -1,6 +1,6 @@
 check_for_missing_forecasters <- function(predictions_cards, forecasters_list, geo_type, signal_name, output_dir) {
   output_file_name <- generate_score_card_file_path(geo_type, signal_name, output_dir)
-  previous_run_forecasters <- readRDS(output_file_name) %>%
+  previous_run_forecasters <- fread(output_file_name, data.table = FALSE) %>%
     filter(signal == signal_name) %>%
     distinct(forecaster) %>%
     pull()

--- a/app/R/data.R
+++ b/app/R/data.R
@@ -1,4 +1,5 @@
 library(aws.s3)
+library(data.table)
 
 # Set application-level caching location. Stores up to 1GB of caches. Removes
 # least recently used objects first.
@@ -33,7 +34,7 @@ getData <- function(filename, s3bucket) {
   if (!is.null(s3bucket)) {
     tryCatch(
       {
-        aws.s3::s3readRDS(object = filename, bucket = s3bucket)
+        s3read_using(fread, data.table = FALSE, object = filename, bucket = s3bucket)
       },
       error = function(e) {
         e
@@ -57,12 +58,12 @@ getFallbackData <- function(filename) {
     filename,
     file.path("../dist/", filename)
   )
-  readRDS(path)
+  fread(path, data.table = FALSE)
 }
 
 
 getCreationDate <- function(loadFile) {
-  dataCreationDate <- loadFile("datetime_created_utc.rds")
+  dataCreationDate <- loadFile("datetime_created_utc.csv.gz")
   return(dataCreationDate %>% pull(datetime) %>% as.Date())
 }
 
@@ -70,16 +71,16 @@ getCreationDate <- function(loadFile) {
 getAllData <- function(loadFile, targetVariable) {
   df <- switch(targetVariable,
     "Deaths" = bind_rows(
-      loadFile("score_cards_state_deaths.rds"),
-      loadFile("score_cards_nation_deaths.rds")
+      loadFile("score_cards_state_deaths.csv.gz"),
+      loadFile("score_cards_nation_deaths.csv.gz")
     ),
     "Cases" = bind_rows(
-      loadFile("score_cards_state_cases.rds"),
-      loadFile("score_cards_nation_cases.rds")
+      loadFile("score_cards_state_cases.csv.gz"),
+      loadFile("score_cards_nation_cases.csv.gz")
     ),
     "Hospitalizations" = bind_rows(
-      loadFile("score_cards_state_hospitalizations.rds"),
-      loadFile("score_cards_nation_hospitalizations.rds")
+      loadFile("score_cards_state_hospitalizations.csv.gz"),
+      loadFile("score_cards_nation_hospitalizations.csv.gz")
     )
   )
 

--- a/app/assets/about.md
+++ b/app/assets/about.md
@@ -91,21 +91,25 @@ The forecasts and scores are available as RDS files and are uploaded weekly to a
 You can use the url https://forecast-eval.s3.us-east-2.amazonaws.com/ + filename to download
 any of the files from the bucket.
 
-For instance: https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_nation_cases.rds to download scores for nation level case predictions.
+For instance: https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_nation_cases.csv.gz to download scores for nation level case predictions.
 
 The available files are:
-* predictions_cards.rds (forecasts)
-* score_cards_nation_cases.rds
-* score_cards_nation_deaths.rds
-* score_cards_state_cases.rds
-* score_cards_state_deaths.rds
-* score_cards_state_hospitalizations.rds
-* score_cards_nation_hospitalizations.rds
+* predictions_cards_confirmed_incidence_num.csv.gz (forecasts for cases)
+* predictions_cards_deaths_incidence_num.csv.gz (forecasts for deaths)
+* predictions_cards_confirmed_admissions_covid_1d.csv.gz (forecasts for hospitalizations)
+* score_cards_nation_cases.csv.gz
+* score_cards_nation_deaths.csv.gz
+* score_cards_state_cases.csv.gz
+* score_cards_state_deaths.csv.gz
+* score_cards_state_hospitalizations.csv.gz
+* score_cards_nation_hospitalizations.csv.gz
 
 You can also connect to AWS and retrieve the data in R. Example of retrieving state cases file:
 
 ```
 library(aws.s3)
+library(data.table)
+
 Sys.setenv("AWS_DEFAULT_REGION" = "us-east-2")
 s3bucket = tryCatch(
   {
@@ -118,14 +122,20 @@ s3bucket = tryCatch(
 
 stateCases = tryCatch(
   {
-    s3readRDS(object = "score_cards_state_cases.rds", bucket = s3bucket)
+    s3read_using(fread, object = "score_cards_state_cases.csv.gz", bucket = s3bucket)
   },
   error = function(e) {
     e
   }
 )
 ```
-  
+
+or using the URL of the file:
+
+```
+library(data.table)
+stateCases <- fread("https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_state_cases.csv.gz")
+```
   
 
 ##### Forecasts with actuals

--- a/app/server.R
+++ b/app/server.R
@@ -402,7 +402,7 @@ server <- function(input, output, session) {
     # Fill gaps so there are line breaks on weeks without data
     # This is failing for CU-select on US deaths (https://github.com/cmu-delphi/forecast-eval/issues/157)
     filteredScoreDf <- filteredScoreDf %>%
-      mutate(Week_End_Date = as.Date(Week_End_Date)) %>% 
+      mutate(Week_End_Date = as.Date(Week_End_Date)) %>%
       as_tsibble(key = c(Forecaster, ahead), index = Week_End_Date) %>%
       group_by(Forecaster, Forecast_Date, ahead) %>%
       fill_gaps(.full = TRUE)

--- a/app/server.R
+++ b/app/server.R
@@ -402,6 +402,7 @@ server <- function(input, output, session) {
     # Fill gaps so there are line breaks on weeks without data
     # This is failing for CU-select on US deaths (https://github.com/cmu-delphi/forecast-eval/issues/157)
     filteredScoreDf <- filteredScoreDf %>%
+      mutate(Week_End_Date = as.Date(Week_End_Date)) %>% 
       as_tsibble(key = c(Forecaster, ahead), index = Week_End_Date) %>%
       group_by(Forecaster, Forecast_Date, ahead) %>%
       fill_gaps(.full = TRUE)

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -qq -y \
 COPY devops/shiny_server.conf /etc/shiny-server/shiny-server.conf
 WORKDIR /srv/shinyapp/
 COPY DESCRIPTION ./
-RUN Rscript -e "devtools::install_deps(dependencies = NA)"
+RUN Rscript -e "devtools::install_deps(dependencies = NA); install.packages('R.utils')"
 COPY dist/*.csv.gz ./
 COPY app/ ./
 RUN chmod -R a+rw .

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -10,6 +10,6 @@ COPY devops/shiny_server.conf /etc/shiny-server/shiny-server.conf
 WORKDIR /srv/shinyapp/
 COPY DESCRIPTION ./
 RUN Rscript -e "devtools::install_deps(dependencies = NA)"
-COPY dist/*.rds ./
+COPY dist/*.csv.gz ./
 COPY app/ ./
 RUN chmod -R a+rw .


### PR DESCRIPTION
Closes https://github.com/cmu-delphi/forecast-eval/issues/262

Switch to `csv.gz` format instead of using RDS. CSV is more flexible in what R packages we can use to read/write the files, and in what languages we want to use (e.g. if we want to rewrite the pipeline in Python but keep the dashboard in R).

`fread` only speeds up the dashboard [slightly](https://github.com/cmu-delphi/forecast-eval/issues/262#issuecomment-1731870182), but offers the opportunity to use faster `data.table` processing in the future.