### PR TITLE
Use old version of node in S3 upload workflow

### DIFF
--- a/.github/workflows/s3_upload_ec2.yml
+++ b/.github/workflows/s3_upload_ec2.yml
@@ -2,6 +2,7 @@ name: Github Actions S3 Deploy (Self-hosted)
 
 env:
   AWS_REGION_NAME : "us-east-2"
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION : true
 
 # Controls when the action will run. 
 on:

--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
-linters: with_defaults(
+linters: modify_defaults(
   line_length_linter(160),
   object_name_linter = NULL,
   object_usage_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -1,9 +1,9 @@
 linters: modify_defaults(
-  line_length_linter(160),
+  defaults = list(line_length_linter = line_length_linter(160),
   object_name_linter = NULL,
   object_usage_linter = NULL,
   cyclocomp_linter = NULL,
   open_curly_linter = NULL,
   closed_curly_linter = NULL,
   object_length_linter = NULL
-  )
+  ))


### PR DESCRIPTION
The `forecast-eval` upload job is failing with:

```
./actions-runner/externals/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by ./actions-runner/externals/node20/bin/node)
./actions-runner/externals/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by ./actions-runner/externals/node20/bin/node)
./actions-runner/externals/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by ./actions-runner/externals/node20/bin/node)
./actions-runner/externals/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by ./actions-runner/externals/node20/bin/node)
./actions-runner/externals/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by ./actions-runner/externals/node20/bin/node)
./actions-runner/externals/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by ./actions-runner/externals/node20/bin/node)
```

[Actions are switching to running on Node20](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/), but the bigchunk’s OS is RHEL 7.x which doesn’t have official support for Node20. This is a temporary fix.